### PR TITLE
fix: Populate fees field for Kraken fiat deposits and withdrawals

### DIFF
--- a/backend/app/services/base_broker_parser.py
+++ b/backend/app/services/base_broker_parser.py
@@ -46,6 +46,7 @@ class ParsedCashTransaction:
     transaction_type: str  # 'Deposit', 'Withdrawal', 'Forex Conversion', etc.
     amount: Decimal
     currency: str
+    fees: Decimal = field(default_factory=lambda: Decimal("0"))
     notes: str | None = None
     raw_data: dict | None = None
 

--- a/backend/app/services/crypto_import_service.py
+++ b/backend/app/services/crypto_import_service.py
@@ -263,6 +263,7 @@ class CryptoImportService:
                         date=cash_txn.date,
                         type=cash_txn.transaction_type,
                         amount=cash_txn.amount,
+                        fees=cash_txn.fees,
                         notes=cash_txn.notes,
                     )
                 )

--- a/backend/app/services/kraken_client.py
+++ b/backend/app/services/kraken_client.py
@@ -605,7 +605,8 @@ class KrakenClient:
                         transaction_type="Deposit",
                         amount=net_amount,
                         currency=asset,
-                        notes=f"Kraken deposit - {entry.get('refid', '')} (fee: {fee})",
+                        fees=fee,
+                        notes=f"Kraken deposit - {entry.get('refid', '')}",
                         raw_data=entry,
                     ),
                 )
@@ -639,7 +640,8 @@ class KrakenClient:
                         transaction_type="Withdrawal",
                         amount=net_amount,  # Total withdrawn including fee
                         currency=asset,
-                        notes=f"Kraken withdrawal - fee: {fee}",
+                        fees=fee,
+                        notes=f"Kraken withdrawal - {entry.get('refid', '')}",
                         raw_data=entry,
                     ),
                 )


### PR DESCRIPTION
## Summary
- Add `fees` field to `ParsedCashTransaction` dataclass so fiat deposits/withdrawals can store fee information
- Pass fees through the import pipeline to the Transaction table
- Populate fees for Kraken fiat deposits and withdrawals
- Clean up notes to remove redundant fee info (now in dedicated field)

## Problem
Kraken deposit transactions stored fees in the `notes` field (e.g., `"Kraken deposit - ABC123 (fee: 3)"`) instead of the dedicated `fees` field. The frontend already supports displaying fees when `tx.fee > 0`, but since the backend never populated this field for fiat transactions, fees were hidden.

## Solution
Extend `ParsedCashTransaction` with a `fees` field (matching `ParsedTransaction`), and populate it in the Kraken client for fiat deposits/withdrawals.

## Test plan
- [ ] Clear existing Kraken transactions for test account (or use fresh sync)
- [ ] Re-sync Kraken via API
- [ ] Open Activity page, find a deposit with a fee
- [ ] Click to expand detail panel
- [ ] Verify "Commission/Fee" row displays the fee amount

## Note
Existing Kraken deposits have `fees=0` with fee in notes. Users can re-sync their Kraken account to get correct fee display.

🤖 Generated with [Claude Code](https://claude.com/claude-code)