### PR TITLE
fix: Persist transactions for crypto broker file uploads

### DIFF
--- a/backend/app/routers/broker_data.py
+++ b/backend/app/routers/broker_data.py
@@ -337,6 +337,24 @@ async def upload_broker_file(
                 "total_records": parsed_data.total_records,
                 "errors": import_stats.get("errors", []),
             }
+        elif broker_type in ("kraken", "bit2c", "binance"):
+            # For crypto brokers, use the CryptoImportService
+            from app.services.crypto_import_service import CryptoImportService
+
+            parsed_data = parser.parse(content)
+            import_service = CryptoImportService(db)
+            import_stats = import_service.import_data(
+                account_id, parsed_data, broker_type.capitalize()
+            )
+
+            source.import_stats = {
+                "transactions": import_stats.get("transactions", {}),
+                "cash_transactions": import_stats.get("cash_transactions", {}),
+                "dividends": import_stats.get("dividends", {}),
+                "holdings_reconstruction": import_stats.get("holdings_reconstruction", {}),
+                "total_records": parsed_data.total_records,
+                "errors": import_stats.get("errors", []),
+            }
         else:
             # For other broker types, use the generic parser (future)
             parsed_data = parser.parse(content)


### PR DESCRIPTION
## Summary

- Fix bug where Kraken/Bit2C/Binance ledger file uploads were parsed but never persisted to the database
- Add conditional block for crypto brokers that uses `CryptoImportService` to properly save transactions

## Problem

When uploading a Kraken ledger CSV file via `/api/broker-data/upload/{account_id}`:
1. File was parsed successfully by `KrakenParser`
2. Stats were calculated (transaction counts, etc.)
3. **Transactions were NEVER persisted to the database**

The account remained empty because the `else` block in `broker_data.py` only counted records without importing them.

## Root Cause

The upload handler had special import logic for:
- **IBKR**: Uses `IBKRImportService`
- **Meitav**: Uses `MeitavImportService`
- **Everything else**: Falls through to a generic block that only counts records

The `CryptoImportService` existed and worked correctly for API imports but was never called for file uploads.

## Test plan

- [ ] Upload Kraken ledger file for an account
- [ ] Verify transactions appear in the account
- [ ] Check database: `SELECT COUNT(*) FROM transactions t JOIN holdings h ON t.holding_id = h.id WHERE h.account_id = <id>;`

🤖 Generated with [Claude Code](https://claude.com/claude-code)