### PR TITLE
fix: correct stats key from 'updated' to 'holdings_updated'

### DIFF
--- a/backend/app/services/brokers/ibkr/flex_import_service.py
+++ b/backend/app/services/brokers/ibkr/flex_import_service.py
@@ -181,7 +181,7 @@ class IBKRFlexImportService:
             stats["end_time"] = datetime.now().isoformat()
             logger.info("IBKR Flex Query import completed successfully")
             logger.info(
-                f"Summary: {reconstruction_stats.get('updated', 0)} holdings reconstructed, "
+                f"Summary: {reconstruction_stats.get('holdings_updated', 0)} holdings reconstructed, "
                 f"{txn_stats['imported']} transactions, "
                 f"{div_stats['imported']} dividends, "
                 f"{transfer_stats['imported']} transfers, "
@@ -369,7 +369,7 @@ class IBKRFlexImportService:
             stats["end_time"] = datetime.now().isoformat()
             logger.info("Historical IBKR import completed successfully")
             logger.info(
-                f"Summary: {reconstruction_stats.get('updated', 0)} holdings reconstructed, "
+                f"Summary: {reconstruction_stats.get('holdings_updated', 0)} holdings reconstructed, "
                 f"{txn_stats['imported']} transactions, "
                 f"{div_stats['imported']} dividends, "
                 f"{transfer_stats['imported']} transfers, "

--- a/backend/tests/test_ibkr_flex_import_date_range.py
+++ b/backend/tests/test_ibkr_flex_import_date_range.py
@@ -58,7 +58,7 @@ class TestImportAllReturnsDateRange:
         mock_import_service._update_asset_prices.return_value = {}
 
         # Mock reconstruction
-        mock_reconstruct.return_value = {"updated": 0}
+        mock_reconstruct.return_value = {"holdings_updated": 0}
 
         stats = IBKRFlexImportService.import_all(
             mock_db, account_id=1, flex_token="token", flex_query_id="query_id"
@@ -119,7 +119,7 @@ class TestImportAllReturnsDateRange:
         mock_import_service._update_asset_prices.return_value = {}
 
         # Mock reconstruction
-        mock_reconstruct.return_value = {"updated": 0}
+        mock_reconstruct.return_value = {"holdings_updated": 0}
 
         stats = IBKRFlexImportService.import_all(
             mock_db, account_id=1, flex_token="token", flex_query_id="query_id"
@@ -169,7 +169,7 @@ class TestImportAllReturnsDateRange:
         mock_import_service._update_asset_prices.return_value = {}
 
         # Mock reconstruction
-        mock_reconstruct.return_value = {"updated": 0}
+        mock_reconstruct.return_value = {"holdings_updated": 0}
 
         stats = IBKRFlexImportService.import_all(
             mock_db, account_id=1, flex_token="token", flex_query_id="query_id"


### PR DESCRIPTION
## Summary
- The reconstruction function returns `holdings_updated` but the log messages in `flex_import_service.py` were looking for `updated`, always reporting 0 holdings reconstructed
- This fix was part of the PR #26 code review but was pushed after the squash merge, so it was not included in main

## Test plan
- [x] `test_ibkr_flex_import_date_range.py` passes with updated mock return values

Generated with [Claude Code](https://claude.ai/code)