### PR TITLE
fix: limit DAGs to 1 concurrent run

### DIFF
--- a/airflow/dags/hourly_broker_import.py
+++ b/airflow/dags/hourly_broker_import.py
@@ -48,6 +48,7 @@ def _extract_error_message(response: requests.Response) -> str:
     schedule="5 * * * *",
     start_date=datetime(2026, 1, 1),
     catchup=False,
+    max_active_runs=1,
     tags=["broker", "import", "hourly"],
 )
 def hourly_broker_import():

--- a/airflow/dags/intraday_price_refresh.py
+++ b/airflow/dags/intraday_price_refresh.py
@@ -40,6 +40,7 @@ default_args = {
     schedule="*/15 * * * *",  # Every 15 minutes, all days
     start_date=datetime(2026, 1, 1),
     catchup=False,
+    max_active_runs=1,
     tags=["portfolio", "prices", "intraday"],
 )
 def intraday_price_refresh():


### PR DESCRIPTION
## Summary
- Add `max_active_runs=1` to `intraday_price_refresh` and `hourly_broker_import` DAGs
- Prevents overlapping DAG runs that could cause duplicate API calls, broker rate limiting, or duplicate transaction imports

## Test plan
- [ ] Verify DAGs parse correctly in Airflow UI
- [ ] Confirm only one DAG run is active at a time when triggered manually in quick succession

🤖 Generated with [Claude Code](https://claude.com/claude-code)