### PR TITLE
fix: resolve daily snapshot DAG failures

### DIFF
--- a/airflow/dags/daily_snapshot_pipeline.py
+++ b/airflow/dags/daily_snapshot_pipeline.py
@@ -14,7 +14,7 @@ import os
 from datetime import date, datetime, timedelta
 
 import requests
-from airflow.sdk import dag, task
+from airflow.sdk import dag, get_current_context, task
 from auth_helper import get_auth_helper
 from dotenv import load_dotenv
 
@@ -36,8 +36,13 @@ default_args = {
 
 
 def _get_snapshot_date() -> date:
-    """Return yesterday's date as the snapshot target."""
-    return date.today() - timedelta(days=1)
+    """Derive the snapshot target date from the DAG run's logical date.
+
+    Uses Airflow's logical_date so that cleared/re-run DAG runs target
+    the correct historical date instead of today.
+    """
+    context = get_current_context()
+    return context["logical_date"].date() - timedelta(days=1)
 
 
 def _make_api_call(endpoint: str, params: dict | None = None) -> dict:
@@ -150,7 +155,7 @@ def daily_snapshot_pipeline():
         )
 
         logger.info("Snapshots created: %s", result.get("snapshots_created", 0))
-        total_value = result.get("total_value_usd", 0)
+        total_value = float(result.get("total_value_usd", 0))
         logger.info("Total value: $%s", f"{total_value:,.2f}")
 
         return result


### PR DESCRIPTION
## Summary

- **Fix Decimal-as-string formatting crash**: `SnapshotService` returns `total_value_usd` as `Decimal`, which FastAPI serializes to a JSON string. The DAG's `:.2f` format specifier failed on the string type. Added `float()` cast before formatting.
- **Fix date drift on DAG re-runs**: Replaced `date.today() - timedelta(days=1)` with derivation from Airflow's `logical_date` via `get_current_context()`, so cleared/backfilled DAG runs target the correct historical date instead of the current date.

## Context

The `daily_snapshot_pipeline` DAG has been failing since Feb 3 (7 consecutive days):
- **Feb 3-7**: `fetch_crypto_prices` failed due to old DAG importing backend `mapped_column` (SQLAlchemy 2.0) into Airflow (SQLAlchemy 1.4) -- already resolved by prior API migration
- **Feb 8-9**: `create_snapshots` failed with `ValueError: Unknown format code 'f' for object of type 'str'` -- fixed in this PR

Missing snapshots for Feb 2-6 were manually backfilled via direct API calls.

## Test plan

- [x] Cleared Feb 9 `create_snapshots` task -- re-ran successfully with `float()` fix
- [x] Cleared Feb 8 `create_snapshots` task -- confirmed `logical_date` derivation targets Feb 7 (correct) instead of Feb 9 (wrong)
- [x] Verified DAG parses without errors in Airflow container
- [x] All 7 previously-failed DAG runs now show success state

🤖 Generated with [Claude Code](https://claude.com/claude-code)