### PR TITLE
fix: handle IBKR Flex Query rate-limit errors (ErrorCode 1018)

### DIFF
--- a/backend/app/services/brokers/ibkr/flex_client.py
+++ b/backend/app/services/brokers/ibkr/flex_client.py
@@ -10,6 +10,15 @@ import requests
 logger = logging.getLogger(__name__)
 
 
+_RETRYABLE_ERROR_CODES: dict[str, str] = {
+    "1018": "rate_limited",  # Too many requests
+    "1019": "pending",  # Statement generation in progress
+}
+
+RATE_LIMIT_SLEEP_SECONDS = 10
+MAX_POLL_INTERVAL_SECONDS = 10
+
+
 class IBKRFlexClient:
     """Client for IBKR Flex Web Service API."""
 
@@ -119,11 +128,10 @@ class IBKRFlexClient:
             error_message = root.findtext("ErrorMessage")
 
             if error_code:
-                if error_code in ("1018", "1019"):
-                    # 1018 = rate limited, 1019 = still generating
-                    status = "rate_limited" if error_code == "1018" else "pending"
-                    logger.info(f"Flex Query {status}: {error_code} - {error_message}")
-                    return status
+                retryable_status = _RETRYABLE_ERROR_CODES.get(error_code)
+                if retryable_status:
+                    logger.info(f"Flex Query {retryable_status}: {error_code} - {error_message}")
+                    return retryable_status
                 logger.error(f"IBKR Flex Query status error: {error_code} - {error_message}")
                 return None
 
@@ -225,12 +233,14 @@ class IBKRFlexClient:
                 logger.error("Error checking Flex Query status")
                 return None
             elif status == "rate_limited":
-                logger.info("Rate limited by IBKR, waiting 10s before retry...")
-                time.sleep(10)
+                logger.info(
+                    f"Rate limited by IBKR, waiting {RATE_LIMIT_SLEEP_SECONDS}s before retry..."
+                )
+                time.sleep(RATE_LIMIT_SLEEP_SECONDS)
             elif status == "pending":
                 logger.debug(f"Flex Query still processing, waiting {current_interval}s...")
                 time.sleep(current_interval)
-                current_interval = min(current_interval * 1.5, 10)
+                current_interval = min(current_interval * 1.5, MAX_POLL_INTERVAL_SECONDS)
 
         logger.error(f"Flex Query timeout after {timeout} seconds")
         return None

--- a/backend/tests/unit/test_flex_client.py
+++ b/backend/tests/unit/test_flex_client.py
@@ -2,7 +2,10 @@
 
 from unittest.mock import MagicMock, patch
 
-from app.services.brokers.ibkr.flex_client import IBKRFlexClient
+from app.services.brokers.ibkr.flex_client import (
+    RATE_LIMIT_SLEEP_SECONDS,
+    IBKRFlexClient,
+)
 
 FAKE_TOKEN = "test-token"
 FAKE_REF = "ref123"
@@ -128,8 +131,7 @@ class TestFetchFlexReportRateLimit:
         result = IBKRFlexClient.fetch_flex_report("token", "query1")
 
         assert result is not None
-        # Rate-limit backoff should be 10 seconds
-        mock_sleep.assert_called_with(10)
+        mock_sleep.assert_called_with(RATE_LIMIT_SLEEP_SECONDS)
         assert mock_status.call_count == 2
 
     @patch(f"{PATCH_PREFIX}.time.time")
@@ -165,5 +167,5 @@ class TestFetchFlexReportRateLimit:
         assert result is not None
         sleep_calls = [call.args[0] for call in mock_sleep.call_args_list]
         assert sleep_calls[0] == 2  # pending: initial interval
-        assert sleep_calls[1] == 10  # rate_limited: flat 10s
+        assert sleep_calls[1] == RATE_LIMIT_SLEEP_SECONDS  # rate_limited: flat backoff
         assert sleep_calls[2] == 3.0  # pending: backoff continued (2 * 1.5)


### PR DESCRIPTION
## Summary

- Fix silent 0-position imports caused by IBKR rate-limit errors being misinterpreted as success
- `get_flex_query_status` now inspects `<ErrorCode>` inside `<FlexStatementResponse>` wrappers instead of blindly treating them as success
- `download_flex_query` validates the response is a `<FlexQueryResponse>` before returning it
- `fetch_flex_report` retries with 10-second backoff on rate-limit (ErrorCode 1018)

## Root Cause

The wizard flow (test-credentials then import) makes rapid successive IBKR API calls, triggering ErrorCode 1018 (rate limit: 1 req/sec, 10 req/min per token). The error was wrapped in `<FlexStatementResponse>` XML, which our code treated as "data is ready." The 247-byte error XML was passed to the parser, which found 0 `<FlexStatement>` elements and silently returned 0 positions.

## Test plan

- [x] Unit tests cover all error code paths in `get_flex_query_status`
- [x] Unit tests cover download validation rejecting error XML
- [x] Unit tests cover retry/timeout behavior in polling loop
- [x] Full backend test suite passes (pre-existing failures only)

Closes #35

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>