### PR TITLE
fix: prevent duplicate account names within the same portfolio

### DIFF
--- a/backend/app/routers/accounts.py
+++ b/backend/app/routers/accounts.py
@@ -12,8 +12,21 @@ from app.models.user import User
 from app.schemas.account import Account as AccountSchema
 from app.schemas.account import AccountCreate, AccountUpdate
 from app.schemas.common import PaginatedResponse
+from app.services.repositories import AccountRepository
 
 router = APIRouter(prefix="/api/accounts", tags=["accounts"])
+
+
+def raise_duplicate_account_name(account_name: str, portfolio_name: str) -> None:
+    """Raise HTTP 409 when an account name already exists in a portfolio."""
+    raise HTTPException(
+        status_code=status.HTTP_409_CONFLICT,
+        detail=(
+            f"An account named '{account_name}' already exists in portfolio "
+            f"'{portfolio_name}'. Rename one of the accounts if you want both "
+            f"in the same portfolio."
+        ),
+    )
 
 
 @router.get("", response_model=PaginatedResponse[AccountSchema])
@@ -95,12 +108,18 @@ async def create_account(
             detail=f"Portfolio {next(iter(invalid_ids))} not found or doesn't belong to you",
         )
 
+    # Fetch target portfolios (reused for both duplicate check and linking)
+    portfolios = db.query(Portfolio).filter(Portfolio.id.in_(account.portfolio_ids)).all()
+
+    # Check for duplicate account name in each target portfolio
+    repo = AccountRepository(db)
+    for portfolio in portfolios:
+        if repo.find_by_name_in_portfolio(account.name, portfolio.id):
+            raise_duplicate_account_name(account.name, portfolio.name)
+
     # Create account
     account_data = account.model_dump(exclude={"portfolio_ids"})
     db_account = Account(**account_data)
-
-    # Link to portfolios
-    portfolios = db.query(Portfolio).filter(Portfolio.id.in_(account.portfolio_ids)).all()
     db_account.portfolios = portfolios
 
     db.add(db_account)
@@ -128,6 +147,14 @@ async def update_account(
     db_account = db.query(Account).filter(Account.id == account_id).first()
 
     update_data = account_update.model_dump(exclude_unset=True)
+    if "name" in update_data:
+        repo = AccountRepository(db)
+        for portfolio in db_account.portfolios:
+            if repo.find_by_name_in_portfolio(
+                update_data["name"], portfolio.id, exclude_account_id=account_id
+            ):
+                raise_duplicate_account_name(update_data["name"], portfolio.name)
+
     for field, value in update_data.items():
         setattr(db_account, field, value)
 

--- a/backend/app/routers/portfolios.py
+++ b/backend/app/routers/portfolios.py
@@ -19,6 +19,7 @@ from app.models.holding import Holding
 from app.models.portfolio import Portfolio
 from app.models.portfolio_account import portfolio_accounts
 from app.models.user import User
+from app.routers.accounts import raise_duplicate_account_name
 from app.schemas.account import Account as AccountSchema
 from app.schemas.portfolio import (
     DeletionPreview,
@@ -30,6 +31,7 @@ from app.schemas.portfolio import (
 from app.schemas.portfolio import (
     Portfolio as PortfolioSchema,
 )
+from app.services.repositories import AccountRepository
 from app.services.shared.currency_service import CurrencyService
 
 router = APIRouter(prefix="/api/portfolios", tags=["portfolios"])
@@ -336,6 +338,11 @@ async def link_account_to_portfolio(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Account already linked to this portfolio",
         )
+
+    # Check for duplicate account name in target portfolio
+    repo = AccountRepository(db)
+    if repo.find_by_name_in_portfolio(account.name, portfolio_id):
+        raise_duplicate_account_name(account.name, portfolio.name)
 
     db.execute(portfolio_accounts.insert().values(portfolio_id=portfolio_id, account_id=account_id))
     db.commit()

--- a/backend/app/services/repositories/account_repository.py
+++ b/backend/app/services/repositories/account_repository.py
@@ -2,6 +2,7 @@
 
 from typing import TYPE_CHECKING
 
+from sqlalchemy import func
 from sqlalchemy.orm import Session, joinedload
 
 from app.models import Account, Portfolio
@@ -75,6 +76,23 @@ class AccountRepository:
             .filter(Account.id.in_(account_ids), Account.is_active.is_(True))
             .all()
         )
+
+    def find_by_name_in_portfolio(
+        self,
+        name: str,
+        portfolio_id: str,
+        *,
+        exclude_account_id: int | None = None,
+    ) -> Account | None:
+        """Find an account with a given name in a portfolio (case-insensitive)."""
+        query = (
+            self._db.query(Account)
+            .join(Account.portfolios)
+            .filter(Portfolio.id == portfolio_id, func.lower(Account.name) == name.lower())
+        )
+        if exclude_account_id is not None:
+            query = query.filter(Account.id != exclude_account_id)
+        return query.first()
 
     def find_all_active_ids(self) -> list[int]:
         """Find all active account IDs (for service accounts)."""

--- a/backend/tests/routers/test_accounts.py
+++ b/backend/tests/routers/test_accounts.py
@@ -91,6 +91,27 @@ def auth_headers(client, test_user):
     return {"Authorization": f"Bearer {tokens['access_token']}"}
 
 
+def make_account(
+    name="Kraken", institution="Kraken", account_type="CryptoExchange", currency="USD"
+):
+    """Create an Account instance with sensible defaults."""
+    return Account(name=name, institution=institution, account_type=account_type, currency=currency)
+
+
+@pytest.fixture
+def portfolio_with_account(db_session, test_user):
+    """Create a portfolio with one 'Kraken' account."""
+    portfolio = Portfolio(name="Main", user_id=test_user.id)
+    db_session.add(portfolio)
+    db_session.flush()
+
+    account = make_account()
+    account.portfolios = [portfolio]
+    db_session.add(account)
+    db_session.commit()
+    return portfolio, account
+
+
 def test_list_accounts_returns_accounts_from_all_portfolios(
     client, auth_headers, test_user, db_session
 ):
@@ -100,13 +121,11 @@ def test_list_accounts_returns_accounts_from_all_portfolios(
     db_session.add_all([portfolio1, portfolio2])
     db_session.flush()
 
-    account1 = Account(
-        name="Kraken", institution="Kraken", account_type="CryptoExchange", currency="USD"
-    )
+    account1 = make_account()
     account1.portfolios = [portfolio1]
 
-    account2 = Account(
-        name="IBKR", institution="Interactive Brokers", account_type="Brokerage", currency="USD"
+    account2 = make_account(
+        name="IBKR", institution="Interactive Brokers", account_type="Brokerage"
     )
     account2.portfolios = [portfolio2]
 
@@ -133,13 +152,11 @@ def test_list_accounts_filtered_by_portfolio(client, auth_headers, test_user, db
     db_session.add_all([portfolio1, portfolio2])
     db_session.flush()
 
-    account1 = Account(
-        name="Kraken", institution="Kraken", account_type="CryptoExchange", currency="USD"
-    )
+    account1 = make_account()
     account1.portfolios = [portfolio1]
 
-    account2 = Account(
-        name="IBKR", institution="Interactive Brokers", account_type="Brokerage", currency="USD"
+    account2 = make_account(
+        name="IBKR", institution="Interactive Brokers", account_type="Brokerage"
     )
     account2.portfolios = [portfolio2]
 
@@ -180,3 +197,143 @@ def test_create_account_with_multiple_portfolios(client, auth_headers, test_user
     assert "portfolio_ids" in data
     assert portfolio1.id in data["portfolio_ids"]
     assert portfolio2.id in data["portfolio_ids"]
+
+
+def test_create_account_duplicate_name_rejected(client, auth_headers, portfolio_with_account):
+    """POST /accounts rejects duplicate account name for the same user."""
+    portfolio, _ = portfolio_with_account
+
+    response = client.post(
+        "/api/accounts",
+        headers=auth_headers,
+        json={
+            "name": "Kraken",
+            "institution": "Kraken",
+            "account_type": "CryptoExchange",
+            "currency": "USD",
+            "portfolio_ids": [portfolio.id],
+        },
+    )
+
+    assert response.status_code == 409
+    detail = response.json()["detail"]
+    assert "already exists" in detail.lower()
+    assert "rename" in detail.lower()
+
+
+def test_create_account_duplicate_name_case_insensitive(
+    client, auth_headers, portfolio_with_account
+):
+    """POST /accounts rejects duplicate names regardless of case."""
+    portfolio, _ = portfolio_with_account
+
+    response = client.post(
+        "/api/accounts",
+        headers=auth_headers,
+        json={
+            "name": "kraken",
+            "institution": "Kraken",
+            "account_type": "CryptoExchange",
+            "currency": "USD",
+            "portfolio_ids": [portfolio.id],
+        },
+    )
+
+    assert response.status_code == 409
+
+
+def test_update_account_duplicate_name_rejected(
+    client, auth_headers, db_session, portfolio_with_account
+):
+    """PUT /accounts/:id rejects rename to an existing account name."""
+    portfolio, _ = portfolio_with_account
+
+    account2 = make_account(
+        name="IBKR", institution="Interactive Brokers", account_type="Brokerage"
+    )
+    account2.portfolios = [portfolio]
+    db_session.add(account2)
+    db_session.commit()
+
+    response = client.put(
+        f"/api/accounts/{account2.id}",
+        headers=auth_headers,
+        json={"name": "Kraken"},
+    )
+
+    assert response.status_code == 409
+    detail = response.json()["detail"]
+    assert "already exists" in detail.lower()
+    assert "rename" in detail.lower()
+
+
+def test_update_account_same_name_allowed(client, auth_headers, portfolio_with_account):
+    """PUT /accounts/:id allows keeping the same name (no-op rename)."""
+    _, account = portfolio_with_account
+
+    response = client.put(
+        f"/api/accounts/{account.id}",
+        headers=auth_headers,
+        json={"name": "Kraken"},
+    )
+
+    assert response.status_code == 200
+
+
+def test_create_account_same_name_in_different_portfolios_allowed(
+    client, auth_headers, test_user, db_session
+):
+    """POST /accounts allows same name in different portfolios for the same user."""
+    portfolio1 = Portfolio(name="Crypto", user_id=test_user.id)
+    portfolio2 = Portfolio(name="Stocks", user_id=test_user.id)
+    db_session.add_all([portfolio1, portfolio2])
+    db_session.flush()
+
+    account = make_account()
+    account.portfolios = [portfolio1]
+    db_session.add(account)
+    db_session.commit()
+
+    response = client.post(
+        "/api/accounts",
+        headers=auth_headers,
+        json={
+            "name": "Kraken",
+            "institution": "Kraken",
+            "account_type": "CryptoExchange",
+            "currency": "EUR",
+            "portfolio_ids": [portfolio2.id],
+        },
+    )
+
+    assert response.status_code == 201
+    assert response.json()["name"] == "Kraken"
+
+
+def test_different_users_can_have_same_account_name(client, db_session, test_user):
+    """Different users can have accounts with the same name."""
+    # Create second user
+    other_user = User(
+        email="test_accounts_other@example.com",
+        password_hash=AuthService.hash_password("test123"),
+        email_verified=True,
+    )
+    db_session.add(other_user)
+    db_session.commit()
+
+    # Both users get a "Kraken" account
+    portfolio1 = Portfolio(name="Main", user_id=test_user.id)
+    portfolio2 = Portfolio(name="Main", user_id=other_user.id)
+    db_session.add_all([portfolio1, portfolio2])
+    db_session.flush()
+
+    acct1 = make_account()
+    acct1.portfolios = [portfolio1]
+    acct2 = make_account()
+    acct2.portfolios = [portfolio2]
+    db_session.add_all([acct1, acct2])
+    db_session.commit()
+
+    # Both should exist without error
+    assert acct1.id != acct2.id
+    assert acct1.name == acct2.name

--- a/backend/tests/routers/test_portfolios.py
+++ b/backend/tests/routers/test_portfolios.py
@@ -91,15 +91,20 @@ def auth_headers(client, test_user):
     return {"Authorization": f"Bearer {tokens['access_token']}"}
 
 
+def make_account(
+    name="Kraken", institution="Kraken", account_type="CryptoExchange", currency="USD"
+):
+    """Create an Account instance with sensible defaults."""
+    return Account(name=name, institution=institution, account_type=account_type, currency=currency)
+
+
 def test_list_portfolios_shows_account_count(client, auth_headers, test_user, db_session):
     """GET /portfolios shows correct account count using relationship."""
     portfolio = Portfolio(name="Crypto", user_id=test_user.id)
     db_session.add(portfolio)
     db_session.flush()
 
-    account = Account(
-        name="Kraken", institution="Kraken", account_type="CryptoExchange", currency="USD"
-    )
+    account = make_account()
     account.portfolios = [portfolio]
     db_session.add(account)
     db_session.commit()
@@ -119,9 +124,7 @@ def test_link_account_to_portfolio(client, auth_headers, test_user, db_session):
     db_session.add_all([portfolio1, portfolio2])
     db_session.flush()
 
-    account = Account(
-        name="Kraken", institution="Kraken", account_type="CryptoExchange", currency="USD"
-    )
+    account = make_account()
     account.portfolios = [portfolio1]
     db_session.add(account)
     db_session.commit()
@@ -145,9 +148,7 @@ def test_link_account_already_linked(client, auth_headers, test_user, db_session
     db_session.add(portfolio)
     db_session.flush()
 
-    account = Account(
-        name="Kraken", institution="Kraken", account_type="CryptoExchange", currency="USD"
-    )
+    account = make_account()
     account.portfolios = [portfolio]
     db_session.add(account)
     db_session.commit()
@@ -167,9 +168,7 @@ def test_unlink_account_from_portfolio(client, auth_headers, test_user, db_sessi
     db_session.add_all([portfolio1, portfolio2])
     db_session.flush()
 
-    account = Account(
-        name="Kraken", institution="Kraken", account_type="CryptoExchange", currency="USD"
-    )
+    account = make_account()
     account.portfolios = [portfolio1, portfolio2]
     db_session.add(account)
     db_session.commit()
@@ -193,9 +192,7 @@ def test_unlink_account_blocked_if_last_portfolio(client, auth_headers, test_use
     db_session.add(portfolio)
     db_session.flush()
 
-    account = Account(
-        name="Kraken", institution="Kraken", account_type="CryptoExchange", currency="USD"
-    )
+    account = make_account()
     account.portfolios = [portfolio]
     db_session.add(account)
     db_session.commit()
@@ -208,6 +205,33 @@ def test_unlink_account_blocked_if_last_portfolio(client, auth_headers, test_use
     assert "only portfolio" in response.json()["detail"].lower()
 
 
+def test_link_account_duplicate_name_rejected(client, auth_headers, test_user, db_session):
+    """POST /portfolios/{id}/accounts/{account_id}/link rejects if name already in portfolio."""
+    portfolio1 = Portfolio(name="Crypto", user_id=test_user.id)
+    portfolio2 = Portfolio(name="Stocks", user_id=test_user.id)
+    db_session.add_all([portfolio1, portfolio2])
+    db_session.flush()
+
+    account1 = make_account()
+    account1.portfolios = [portfolio1]
+
+    account2 = make_account(currency="EUR")
+    account2.portfolios = [portfolio2]
+
+    db_session.add_all([account1, account2])
+    db_session.commit()
+
+    # Try to link account2 ("Kraken") into portfolio1 which already has a "Kraken"
+    response = client.post(
+        f"/api/portfolios/{portfolio1.id}/accounts/{account2.id}/link", headers=auth_headers
+    )
+
+    assert response.status_code == 409
+    detail = response.json()["detail"]
+    assert "already exists" in detail.lower()
+    assert "rename" in detail.lower()
+
+
 def test_get_linkable_accounts(client, auth_headers, test_user, db_session):
     """GET /portfolios/{id}/linkable-accounts returns accounts not in this portfolio."""
     portfolio1 = Portfolio(name="Crypto", user_id=test_user.id)
@@ -215,13 +239,11 @@ def test_get_linkable_accounts(client, auth_headers, test_user, db_session):
     db_session.add_all([portfolio1, portfolio2])
     db_session.flush()
 
-    account1 = Account(
-        name="Kraken", institution="Kraken", account_type="CryptoExchange", currency="USD"
-    )
+    account1 = make_account()
     account1.portfolios = [portfolio1]
 
-    account2 = Account(
-        name="IBKR", institution="Interactive Brokers", account_type="Brokerage", currency="USD"
+    account2 = make_account(
+        name="IBKR", institution="Interactive Brokers", account_type="Brokerage"
     )
     account2.portfolios = [portfolio2]
 
@@ -248,15 +270,11 @@ def test_deletion_preview_shows_exclusive_and_shared(client, auth_headers, test_
     db_session.flush()
 
     # Exclusive to Crypto
-    account1 = Account(
-        name="Bit2C", institution="Bit2C", account_type="CryptoExchange", currency="ILS"
-    )
+    account1 = make_account(name="Bit2C", institution="Bit2C", currency="ILS")
     account1.portfolios = [portfolio1]
 
     # Shared between both
-    account2 = Account(
-        name="Kraken", institution="Kraken", account_type="CryptoExchange", currency="USD"
-    )
+    account2 = make_account()
     account2.portfolios = [portfolio1, portfolio2]
 
     db_session.add_all([account1, account2])
@@ -283,14 +301,10 @@ def test_delete_portfolio_removes_exclusive_keeps_shared(
     db_session.add_all([portfolio1, portfolio2])
     db_session.flush()
 
-    account1 = Account(
-        name="Bit2C", institution="Bit2C", account_type="CryptoExchange", currency="ILS"
-    )
+    account1 = make_account(name="Bit2C", institution="Bit2C", currency="ILS")
     account1.portfolios = [portfolio1]
 
-    account2 = Account(
-        name="Kraken", institution="Kraken", account_type="CryptoExchange", currency="USD"
-    )
+    account2 = make_account()
     account2.portfolios = [portfolio1, portfolio2]
 
     db_session.add_all([account1, account2])

--- a/frontend/src/components/AccountWizard/__tests__/AccountDetailsStep.test.jsx
+++ b/frontend/src/components/AccountWizard/__tests__/AccountDetailsStep.test.jsx
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { AccountDetailsStep } from '../steps/AccountDetailsStep';
+
+const defaultProps = {
+  broker: { name: 'Kraken', defaultCurrency: 'USD' },
+  category: { defaultAccountType: 'Crypto' },
+  existingAccountNames: [],
+  onSubmit: vi.fn(),
+  onBack: vi.fn(),
+};
+
+describe('AccountDetailsStep', () => {
+  it('suggests default name when no existing accounts', () => {
+    render(<AccountDetailsStep {...defaultProps} />);
+    expect(screen.getByDisplayValue('My Kraken Account')).toBeInTheDocument();
+  });
+
+  it('suggests numbered name when default already exists', () => {
+    render(
+      <AccountDetailsStep
+        {...defaultProps}
+        existingAccountNames={['My Kraken Account']}
+      />
+    );
+    expect(screen.getByDisplayValue('My Kraken Account #2')).toBeInTheDocument();
+  });
+
+  it('suggests #3 when both base and #2 exist', () => {
+    render(
+      <AccountDetailsStep
+        {...defaultProps}
+        existingAccountNames={['My Kraken Account', 'My Kraken Account #2']}
+      />
+    );
+    expect(screen.getByDisplayValue('My Kraken Account #3')).toBeInTheDocument();
+  });
+
+  it('is case-insensitive when checking for duplicates', () => {
+    render(
+      <AccountDetailsStep
+        {...defaultProps}
+        existingAccountNames={['my kraken account']}
+      />
+    );
+    expect(screen.getByDisplayValue('My Kraken Account #2')).toBeInTheDocument();
+  });
+
+  it('uses generic name when no broker specified', () => {
+    render(<AccountDetailsStep {...defaultProps} broker={null} />);
+    expect(screen.getByDisplayValue('My Account')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/AccountWizard/index.jsx
+++ b/frontend/src/components/AccountWizard/index.jsx
@@ -39,7 +39,7 @@ function formatDateForDisplay(dateStr, fallback = 'N/A') {
   }
 }
 
-export function AccountWizard({ isOpen, onClose, portfolioId, linkableAccounts = [] }) {
+export function AccountWizard({ isOpen, onClose, portfolioId, linkableAccounts = [], existingAccountNames = [] }) {
   const navigate = useNavigate();
   const [currentStep, setCurrentStep] = useState(1);
   const [maxReachedStep, setMaxReachedStep] = useState(1);
@@ -476,6 +476,7 @@ export function AccountWizard({ isOpen, onClose, portfolioId, linkableAccounts =
       <AccountDetailsStep
         broker={brokerConfig}
         category={category}
+        existingAccountNames={existingAccountNames}
         onSubmit={handleDetailsSubmit}
         onBack={() => goToStep(isManualFlow ? 1 : 2)}
       />

--- a/frontend/src/components/AccountWizard/steps/AccountDetailsStep.jsx
+++ b/frontend/src/components/AccountWizard/steps/AccountDetailsStep.jsx
@@ -18,10 +18,18 @@ const ACCOUNT_TYPES = [
   { value: 'Savings', label: 'Savings' },
 ];
 
-export function AccountDetailsStep({ broker, category, onSubmit, onBack }) {
-  const defaultName = broker
-    ? `My ${broker.name} Account`
-    : 'My Account';
+function generateUniqueName(baseName, existingNames) {
+  const lowerNames = new Set(existingNames.map((n) => n.toLowerCase()));
+  if (!lowerNames.has(baseName.toLowerCase())) return baseName;
+  for (let i = 2; ; i++) {
+    const candidate = `${baseName} #${i}`;
+    if (!lowerNames.has(candidate.toLowerCase())) return candidate;
+  }
+}
+
+export function AccountDetailsStep({ broker, category, existingAccountNames = [], onSubmit, onBack }) {
+  const baseName = broker ? `My ${broker.name} Account` : 'My Account';
+  const defaultName = generateUniqueName(baseName, existingAccountNames);
 
   const [name, setName] = useState(defaultName);
   const [description, setDescription] = useState('');

--- a/frontend/src/pages/Accounts.jsx
+++ b/frontend/src/pages/Accounts.jsx
@@ -883,6 +883,7 @@ export default function Accounts() {
         }}
         portfolioId={selectedPortfolioId}
         linkableAccounts={linkableAccounts}
+        existingAccountNames={accounts.map((a) => a.name)}
       />
 
       {/* Delete/Unlink Confirmation Dialog */}


### PR DESCRIPTION
## Summary
- Adds case-insensitive name uniqueness checks **scoped per portfolio** on account create, update (rename), and link operations
- Error messages suggest renaming one of the accounts when a conflict is detected
- Frontend account wizard auto-suggests "My Kraken Account #2" when the base name is already taken

## Changes

### Backend
- **`AccountRepository.find_by_name_in_portfolio()`** -- new case-insensitive lookup with optional `exclude_account_id` for self-rename
- **`raise_duplicate_account_name()`** -- shared helper in accounts router, reused by portfolios router
- **`create_account`** -- checks each target portfolio for name collision
- **`update_account`** -- checks all portfolios the account belongs to (excludes self)
- **`link_account_to_portfolio`** -- checks target portfolio before linking

### Frontend
- **`generateUniqueName()`** -- appends `#2`, `#3`, etc. when base name is taken (case-insensitive)
- Threads `existingAccountNames` from Accounts page through AccountWizard to AccountDetailsStep

### Tests
- 7 new backend tests (create duplicate, case-insensitive, update duplicate, self-rename allowed, cross-portfolio allowed, different users allowed, link duplicate)
- 5 new frontend tests for name suggestion logic
- Existing tests refactored with `make_account()` factory and `portfolio_with_account` fixture

## Test plan
- [x] Backend: all 12 new tests pass
- [x] Frontend: all 5 AccountDetailsStep tests pass
- [x] Existing test suite unaffected (no new failures)
- [ ] Manual: create two accounts with same name in same portfolio -- expect 409
- [ ] Manual: create two accounts with same name in different portfolios -- expect success
- [ ] Manual: rename account to collide with existing -- expect 409
- [ ] Manual: link account to portfolio with same-named account -- expect 409
- [ ] Manual: verify wizard suggests "#2" suffix when name is taken

🤖 Generated with [Claude Code](https://claude.com/claude-code)