### PR TITLE
fix: align service account login with identifier-based auth

### DIFF
--- a/airflow/dags/auth_helper.py
+++ b/airflow/dags/auth_helper.py
@@ -58,7 +58,7 @@ class ServiceAuthHelper:
 
         response = requests.post(
             f"{self.backend_url}/api/auth/login",
-            json={"email": self.email, "password": self.password},
+            json={"identifier": self.email, "password": self.password},
             timeout=30,
         )
 

--- a/backend/scripts/create_service_account.py
+++ b/backend/scripts/create_service_account.py
@@ -44,8 +44,11 @@ def create_service_account(db: DBSession, password: str | None = None) -> tuple[
     # Generate password if not provided
     password = password or os.getenv("AIRFLOW_SERVICE_PASSWORD") or generate_secure_password()
 
+    username = SERVICE_EMAIL.split("@")[0].replace("-", "_")
+
     user = User(
         email=SERVICE_EMAIL,
+        username=username,
         password_hash=AuthService.hash_password(password),
         is_active=True,
         is_service_account=True,


### PR DESCRIPTION
## Summary
- Fix Airflow DAG authentication failures caused by login payload mismatch after username feature (#44)
- Update `auth_helper.py` to send `identifier` instead of `email` in login payload, matching the new `UserLogin` schema
- Add missing `username` field to `create_service_account.py` to prevent NOT NULL violations when creating new service accounts

## Test plan
- [x] Backend auth API tests pass (`test_auth_api.py`)
- [ ] Trigger `daily_snapshot_pipeline` DAG and verify it authenticates successfully
- [ ] Trigger `hourly_broker_import` DAG and verify it authenticates successfully
- [ ] Run `create_service_account.py` on a fresh DB to verify username is set correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)