### PR TITLE
feat: add Bank Leumi frontend support and broker logos

### DIFF
--- a/frontend/src/components/AccountWizard/BrokerLogo.jsx
+++ b/frontend/src/components/AccountWizard/BrokerLogo.jsx
@@ -3,6 +3,8 @@ import { cn } from '../../lib/index.js';
 const BROKER_LOGOS = {
   ibkr: 'https://cdn.brandfetch.io/idcABCQwX-/w/400/h/400/theme/dark/icon.jpeg',
   meitav: 'https://cdn.brandfetch.io/idT29sW48-/w/400/h/400/theme/dark/logo.png',
+  bank_hapoalim: 'https://cdn.brandfetch.io/ido_bZv0cC/w/400/h/400/theme/dark/logo.png',
+  leumi: 'https://cdn.brandfetch.io/idqdUVKqfU/w/400/h/400/theme/dark/icon.jpeg',
   kraken: 'https://cdn.brandfetch.io/idYQrXoH-Q/w/400/h/400/theme/dark/symbol.png',
   bit2c: 'https://cdn.brandfetch.io/idatfQiwS7/w/400/h/400/theme/dark/icon.jpeg',
   binance: 'https://cdn.brandfetch.io/id-pjrLx_q/w/400/h/400/theme/dark/symbol.png',

--- a/frontend/src/components/AccountWizard/__tests__/BrokerLogo.test.jsx
+++ b/frontend/src/components/AccountWizard/__tests__/BrokerLogo.test.jsx
@@ -21,7 +21,7 @@ describe('BrokerLogo', () => {
   });
 
   it('renders correct logo for each known broker', () => {
-    const brokers = ['ibkr', 'meitav', 'kraken', 'bit2c', 'binance'];
+    const brokers = ['ibkr', 'meitav', 'bank_hapoalim', 'leumi', 'kraken', 'bit2c', 'binance'];
 
     brokers.forEach((broker) => {
       const { unmount } = render(<BrokerLogo type={broker} />);

--- a/frontend/src/components/AccountWizard/constants/brokerConfig.js
+++ b/frontend/src/components/AccountWizard/constants/brokerConfig.js
@@ -121,6 +121,32 @@ export const BROKERS = {
     fields: {},
   },
 
+  leumi: {
+    type: 'leumi',
+    name: 'Bank Leumi',
+    shortName: 'Leumi',
+    category: 'brokerage',
+    defaultCurrency: 'ILS',
+    defaultAccountType: 'Investment',
+    hasApi: false,
+    supportedFormats: ['.xls'],
+    instructions: {
+      file: {
+        title: 'Export from Bank Leumi',
+        steps: [
+          'Log into Bank Leumi online banking (hb2.bankleumi.co.il)',
+          'Navigate to Investments > Securities Portfolio',
+          'Click on "Transaction History"',
+          'Select your date range (up to 6 months per export)',
+          'Export as Excel file (.xls)',
+        ],
+        formats: 'Excel (.xls) files',
+        note: 'Bank Leumi exports cover up to 6 months per file. For longer history, export multiple files.',
+      },
+    },
+    fields: {},
+  },
+
   kraken: {
     type: 'kraken',
     name: 'Kraken',

--- a/frontend/src/pages/Accounts.jsx
+++ b/frontend/src/pages/Accounts.jsx
@@ -17,6 +17,7 @@ import { Skeleton } from '../components/ui';
 import { ApiCredentialsModal } from '../components/ApiCredentialsModal';
 import { AccountWizard } from '../components/AccountWizard';
 import { BatchUploadModal } from '../components/BatchUploadModal';
+import { BrokerLogo } from '../components/AccountWizard/BrokerLogo';
 import { CoverageTimeline } from '../components/CoverageTimeline';
 
 // ============================================
@@ -43,14 +44,6 @@ function XMarkIcon({ className }) {
   return (
     <svg className={className} fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
       <path strokeLinecap="round" strokeLinejoin="round" d="M6 18 18 6M6 6l12 12" />
-    </svg>
-  );
-}
-
-function CloudArrowUpIcon({ className }) {
-  return (
-    <svg className={className} fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
-      <path strokeLinecap="round" strokeLinejoin="round" d="M12 16.5V9.75m0 0 3 3m-3-3-3 3M6.75 19.5a4.5 4.5 0 0 1-1.41-8.775 5.25 5.25 0 0 1 10.233-2.33 3 3 0 0 1 3.758 3.848A3.752 3.752 0 0 1 18 19.5H6.75Z" />
     </svg>
   );
 }
@@ -352,9 +345,13 @@ function AccountCard({ account, currency, brokerConfig, onDelete, onRename, onRe
         className="flex items-center justify-between p-5 cursor-pointer hover:bg-[var(--bg-tertiary)] transition-colors"
       >
         <div className="flex items-center gap-4">
-          <div className="p-3 rounded-xl bg-accent/10">
-            <ChartBarIcon className="w-6 h-6 text-accent" />
-          </div>
+          {account.broker_type ? (
+            <BrokerLogo type={account.broker_type} className="size-12 rounded-lg" />
+          ) : (
+            <div className="p-3 rounded-xl bg-accent/10">
+              <ChartBarIcon className="w-6 h-6 text-accent" />
+            </div>
+          )}
           <div>
             <div className="flex items-center gap-2">
               {isEditing ? (


### PR DESCRIPTION
## Summary
- Add Bank Leumi to the account wizard with file-based import config (`.xls` SpreadsheetML format, ILS currency, export instructions)
- Add Brandfetch CDN logos for Bank Leumi and Bank Hapoalim in `BrokerLogo` component
- Display broker logos on the accounts list page, replacing the generic chart icon in each account card

## Test plan
- [ ] Open the account wizard and verify Bank Leumi appears under "Brokerage" category
- [ ] Verify Bank Leumi shows its logo (not text fallback) in the broker selection grid
- [ ] Verify Bank Hapoalim also shows its logo (was previously text fallback)
- [ ] Create a Bank Leumi account and confirm `.xls` is the accepted file format
- [ ] Navigate to the Accounts page and verify each account card shows its broker logo
- [ ] Verify accounts without a `broker_type` still show the generic chart icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)