### PR TITLE
fix: correct IBKR Flex Query section validation names

### DIFF
--- a/backend/app/services/brokers/ibkr/parser.py
+++ b/backend/app/services/brokers/ibkr/parser.py
@@ -1161,17 +1161,17 @@ class IBKRParser:
 
         return None
 
-    # Section name -> XPath to detect the section *container* (not child elements).
+    # Display name (matching IBKR Flex Query UI) -> XPath for the container element.
     # Checks whether the user configured the section in their Flex Query,
     # regardless of whether the section has data (e.g. zero trades is fine).
+    # Note: Transfers are extracted from CashTransactions, no separate section needed.
     _REQUIRED_SECTIONS: list[tuple[str, str]] = [
         ("Account Information", ".//AccountInformation"),
         ("Open Positions", ".//OpenPositions"),
         ("Trades", ".//Trades"),
         ("Cash Transactions", ".//CashTransactions"),
-        ("Transfers", ".//Transfers"),
-        ("Forex Trades", ".//ConversionRates"),
-        ("Cash Report", ".//CashReport"),
+        ("Forex Balances", ".//FxPositions"),
+        ("Forex P&L Details", ".//FxTransactions"),
     ]
 
     @staticmethod

--- a/backend/tests/unit/test_ibkr_parser_types.py
+++ b/backend/tests/unit/test_ibkr_parser_types.py
@@ -216,9 +216,8 @@ class TestValidateRequiredSections:
             '<OpenPositions><OpenPosition symbol="AAPL" /></OpenPositions>'
             '<Trades><Trade symbol="AAPL" /></Trades>'
             '<CashTransactions><CashTransaction type="Dividends" /></CashTransactions>'
-            "<Transfers><Transfer /></Transfers>"
-            "<ConversionRates><ConversionRate /></ConversionRates>"
-            '<CashReport><CashReportCurrency currency="USD" /></CashReport>'
+            '<FxPositions><FxPosition currency="USD" /></FxPositions>'
+            "<FxTransactions><FxTransaction /></FxTransactions>"
         )
 
     def test_all_sections_present(self):
@@ -231,9 +230,8 @@ class TestValidateRequiredSections:
             "<OpenPositions><OpenPosition /></OpenPositions>"
             "<Trades><Trade /></Trades>"
             "<CashTransactions><CashTransaction /></CashTransactions>"
-            "<Transfers><Transfer /></Transfers>"
-            "<ConversionRates><ConversionRate /></ConversionRates>"
-            "<CashReport><CashReportCurrency /></CashReport>"
+            "<FxPositions><FxPosition /></FxPositions>"
+            "<FxTransactions><FxTransaction /></FxTransactions>"
         )
         missing = IBKRParser.validate_required_sections(root)
         assert "Account Information" in missing
@@ -243,12 +241,12 @@ class TestValidateRequiredSections:
         missing = IBKRParser.validate_required_sections(root)
         assert "Account Information" in missing
         assert "Open Positions" in missing
-        assert "Cash Report" in missing
+        assert "Forex Balances" in missing
 
     def test_empty_statement(self):
         root = _build_xml("")
         missing = IBKRParser.validate_required_sections(root)
-        assert len(missing) == 7
+        assert len(missing) == 6
 
     def test_empty_containers_are_present(self):
         """Sections configured but with no data should NOT be flagged as missing."""
@@ -257,9 +255,8 @@ class TestValidateRequiredSections:
             "<OpenPositions />"
             "<Trades />"
             "<CashTransactions />"
-            "<Transfers />"
-            "<ConversionRates />"
-            "<CashReport />"
+            "<FxPositions />"
+            "<FxTransactions />"
         )
         missing = IBKRParser.validate_required_sections(root)
         assert missing == []


### PR DESCRIPTION
## Summary
- Fixed `_REQUIRED_SECTIONS` to use correct XML container names and IBKR Flex Query UI display names
- Replaced "Forex Trades" / `ConversionRates` (never exists) with "Forex Balances" / `FxPositions` and "Forex P&L Details" / `FxTransactions`
- Removed "Cash Report" (never present in real XML; `extract_cash_balances` already falls back to `FxPositions`)
- Removed "Transfers" (transfer data comes from `CashTransactions` which is already required; `<Transfers>` container was empty in all 12 sample XML files)

## Test plan
- [x] All 5 `TestValidateRequiredSections` tests updated and passing
- [x] All 26 IBKR parser + orchestrator tests passing
- [ ] Manual: recreate IBKR account with Flex Query containing the corrected sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)