### PR TITLE
feat: rebuild Accounts page into componentized grid layout

### DIFF
--- a/docs/plans/2026-04-07-accounts-page.md
+++ b/docs/plans/2026-04-07-accounts-page.md
@@ -1,0 +1,123 @@
+# Accounts Page Rebuild
+
+**Issue:** #127
+**Branch:** `feat/accounts-page`
+**Date:** 2026-04-07
+
+## Goal
+
+Replace the monolithic `Accounts.jsx` (900+ lines, accordion cards) with a componentized
+grid-card layout matching the accounts-playground mock. Follows the same decomposition
+pattern used in Dashboard (#136) and Activity (#139).
+
+## Mock Summary
+
+1. **Title bar** -- "Accounts" + subtitle (`N accounts`) + "Add Account" button
+2. **Allocation strip** -- horizontal stacked bar showing each account's share, with
+   labeled badges underneath (broker color dot + name + %)
+3. **Account card grid** -- `auto-fill, minmax(340px, 1fr)` grid of cards, each showing:
+   - Broker logo + account name + type badge (Brokerage / Crypto / Pension)
+   - Total value (large mono) + allocation %
+   - Top 3 holdings as pills (`AAPL $4,746`) + "+N more" pill
+   - Footer: sync dot (green/amber/red) + "Last synced X ago"
+4. **"+ Add Account"** dashed placeholder card at the end of the grid
+5. **Account sidebar** (slide-over on card click):
+   - Header: logo + name, type + allocation%, View Details btn, close btn
+   - Value block: total value + P&L with color
+   - Summary card: Total Cost, Unrealized P&L, Positions, Sync Status
+   - Holdings card: per-holding rows with icon, symbol, qty, value, P&L
+   - Recent Activity card: latest transactions
+
+## Token Mapping (mock -> real CSS vars)
+
+| Mock token        | App token             |
+|-------------------|-----------------------|
+| `--bg-card`       | `--bg-secondary`      |
+| `--bg-card-hover` | `--bg-tertiary`       |
+| `--bg-elevated`   | `--bg-tertiary`       |
+| `--border`        | `--border-primary`    |
+| `--border-subtle` | `--border-subtle`     |
+| `--text-primary`  | `--text-primary`      |
+| `--text-secondary`| `--text-secondary`    |
+| `--text-muted`    | `--text-tertiary`     |
+| `--text-faint`    | `--text-faint`        |
+| `--accent`        | `--accent-primary`    |
+| `--accent-hover`  | `--accent-hover`      |
+| `--accent-muted`  | `--blue-muted`        |
+| `--positive`      | `--positive`          |
+| `--negative`      | `--negative`          |
+| `--warning`       | `--warning`           |
+
+## Data Sources
+
+| Data need                       | Endpoint                                                      |
+|---------------------------------|---------------------------------------------------------------|
+| Account list                    | `GET /api/accounts?is_active=true&portfolio_id={pid}`         |
+| Account values + holding counts | `GET /api/dashboard/summary?display_currency={c}&portfolio_id={pid}` |
+| Per-account holdings + P&L      | `GET /api/positions?display_currency={c}&portfolio_id={pid}`  |
+| Broker configs                  | `GET /api/broker-data/supported-brokers`                      |
+| Recent activity (sidebar only)  | `GET /api/transactions?account_name={name}&limit=5` (lazy)    |
+
+Positions response includes `accounts[]` array per position with per-account `market_value`,
+`pnl`, `quantity` -- group by `account_id` to get holdings per account.
+
+## Architecture
+
+```
+pages/Accounts.jsx                  (thin orchestrator, ~100 lines)
+hooks/useAccountsData.js            (data fetching + enrichment)
+components/accounts/
+  AllocationStrip.jsx               (stacked bar + badges)
+  AccountCard.jsx                   (single grid card)
+  AccountGrid.jsx                   (grid container + add-account card)
+  AccountSidebar.jsx                (slide-over detail panel)
+  icons.jsx                         (PlusIcon, ExternalLinkIcon)
+  index.js                          (barrel exports)
+```
+
+Existing components reused: `PageContainer`, `Skeleton`, `BrokerLogo`, `AccountWizard`,
+`AlertDialog` (inlined in old page -- extract or keep inline), `useSlideover`.
+
+## Broker Colors (for allocation bar)
+
+```js
+const BROKER_COLORS = {
+  ibkr: '#E31937',
+  meitav: '#2563EB',
+  kraken: '#7B61FF',
+  bit2c: '#F7931A',
+  binance: '#F0B90B',
+};
+```
+Fallback: `var(--text-tertiary)` for unknown brokers.
+
+## Tasks
+
+### 1. Create `useAccountsData` hook
+- Fetch accounts + dashboard summary + positions in parallel
+- Build `accountsMap` from dashboard summary (id -> value, holding_count)
+- Group positions by account_id using positions[].accounts[] breakdown
+- Return `{ accounts, accountHoldings, totalValue, loading, error, currency }`
+- Each account enriched with: value, holdingCount, lastSync, syncStatus, allocationPct
+
+### 2. Build components
+- **AllocationStrip**: stacked bar segments (width proportional to value), badges below
+- **AccountCard**: broker logo, name+type badge, value+allocation%, top 3 holding pills, sync footer
+- **AccountGrid**: CSS grid wrapper + "Add Account" dashed card
+- **AccountSidebar**: uses `useSlideover`, shows summary/holdings/activity when account selected
+
+### 3. Rebuild `Accounts.jsx`
+- Thin page component using `useAccountsData` + new components
+- Preserve: AccountWizard integration, delete/unlink dialog, rename capability
+- Loading/error states using PageContainer + Skeleton (same pattern as Activity)
+
+### 4. Verify & simplify
+- Test on localhost:5176 (isolated vite)
+- Run /simplify-branch
+- Create PR targeting main
+
+## Preserved Functionality
+
+The existing page's management features (rename, delete/unlink, API credentials, batch upload)
+move to the AccountSidebar's action buttons and the AccountDetail page (`/accounts/:id`).
+The AccountWizard remains triggered by the "Add Account" button.

--- a/frontend/src/components/accounts/AccountCard.jsx
+++ b/frontend/src/components/accounts/AccountCard.jsx
@@ -9,26 +9,30 @@ export function AccountCard({ account, holdings, currency, onClick, onDelete }) 
   const remainingCount = (holdings || []).length - 3;
   const [showConfirm, setShowConfirm] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
+  const [deleteError, setDeleteError] = useState(null);
   const isShared = (account.portfolio_ids?.length ?? 0) > 1;
 
   const handleDeleteClick = (e) => {
     e.stopPropagation();
+    setDeleteError(null);
     setShowConfirm(true);
   };
 
   const handleCancel = (e) => {
     e.stopPropagation();
     setShowConfirm(false);
+    setDeleteError(null);
   };
 
   const handleConfirm = async (e) => {
     e.stopPropagation();
     setIsDeleting(true);
+    setDeleteError(null);
     try {
       await onDelete?.(account.id);
-    } catch {
+    } catch (err) {
       setIsDeleting(false);
-      setShowConfirm(false);
+      setDeleteError(err.message || 'Failed to delete account');
     }
   };
 
@@ -112,6 +116,9 @@ export function AccountCard({ account, holdings, currency, onClick, onDelete }) 
               ? 'Remove this account from the current portfolio?'
               : 'Permanently delete this account and all its data?'}
           </p>
+          {deleteError && (
+            <p className="text-[11px] text-[var(--negative)] text-center">{deleteError}</p>
+          )}
           <div className="flex gap-2 w-full">
             <button
               onClick={handleCancel}

--- a/frontend/src/components/accounts/AccountCard.jsx
+++ b/frontend/src/components/accounts/AccountCard.jsx
@@ -1,18 +1,44 @@
+import { useState } from 'react';
 import { cn, formatCurrency } from '../../lib';
 import { BrokerLogo } from '../AccountWizard/BrokerLogo';
+import { TrashIcon } from './icons';
 import { TYPE_LABELS } from './constants';
 
-export function AccountCard({ account, holdings, currency, onClick }) {
+export function AccountCard({ account, holdings, currency, onClick, onDelete }) {
   const topHoldings = (holdings || []).slice(0, 3);
   const remainingCount = (holdings || []).length - 3;
+  const [showConfirm, setShowConfirm] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const isShared = (account.portfolio_ids?.length ?? 0) > 1;
+
+  const handleDeleteClick = (e) => {
+    e.stopPropagation();
+    setShowConfirm(true);
+  };
+
+  const handleCancel = (e) => {
+    e.stopPropagation();
+    setShowConfirm(false);
+  };
+
+  const handleConfirm = async (e) => {
+    e.stopPropagation();
+    setIsDeleting(true);
+    try {
+      await onDelete?.(account.id);
+    } catch {
+      setIsDeleting(false);
+      setShowConfirm(false);
+    }
+  };
 
   return (
     <div
-      onClick={() => onClick(account)}
+      onClick={() => !showConfirm && onClick(account)}
       className={cn(
-        'bg-[var(--bg-secondary)] border border-[var(--border-primary)] rounded-xl',
+        'relative bg-[var(--bg-secondary)] border border-[var(--border-primary)] rounded-xl',
         'p-5 cursor-pointer transition-all flex flex-col gap-3.5',
-        'hover:border-[var(--accent-primary)] hover:shadow-[0_0_0_1px_var(--accent-primary)]'
+        !showConfirm && 'hover:border-[var(--accent-primary)] hover:shadow-[0_0_0_1px_var(--accent-primary)]'
       )}
     >
       {/* Header: logo + name + type */}
@@ -60,13 +86,49 @@ export function AccountCard({ account, holdings, currency, onClick }) {
         </div>
       )}
 
-      {/* Footer: sync status */}
-      <div className="flex items-center pt-2.5 border-t border-[var(--border-subtle)]">
+      {/* Footer: sync status + trash */}
+      <div className="flex items-center justify-between pt-2.5 border-t border-[var(--border-subtle)]">
         <div className="flex items-center gap-1.5 text-[11px] text-[var(--text-faint)]">
           <div className={cn('w-1.5 h-1.5 rounded-full shrink-0', account.syncStatus.color)} />
           Last synced {account.lastSyncFormatted}
         </div>
+        <button
+          onClick={handleDeleteClick}
+          className="w-6 h-6 flex items-center justify-center rounded text-[var(--text-faint)] hover:text-[var(--negative)] hover:bg-[var(--negative)]/10 transition-all cursor-pointer"
+          title={isShared ? 'Remove from portfolio' : 'Delete account'}
+        >
+          <TrashIcon className="w-3.5 h-3.5" />
+        </button>
       </div>
+
+      {/* Delete confirmation overlay */}
+      {showConfirm && (
+        <div
+          className="absolute inset-0 rounded-xl bg-[var(--bg-secondary)]/95 backdrop-blur-[2px] flex flex-col items-center justify-center gap-3 p-5 border border-[var(--negative)]/30"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <p className="text-[13px] text-[var(--text-secondary)] text-center">
+            {isShared
+              ? 'Remove this account from the current portfolio?'
+              : 'Permanently delete this account and all its data?'}
+          </p>
+          <div className="flex gap-2 w-full">
+            <button
+              onClick={handleCancel}
+              className="flex-1 px-3 py-1.5 rounded-md text-xs font-medium bg-[var(--bg-primary)] border border-[var(--border-primary)] text-[var(--text-secondary)] hover:text-[var(--text-primary)] transition-colors cursor-pointer"
+            >
+              Cancel
+            </button>
+            <button
+              onClick={handleConfirm}
+              disabled={isDeleting}
+              className="flex-1 px-3 py-1.5 rounded-md text-xs font-semibold bg-[var(--negative)] text-white hover:opacity-90 transition-opacity cursor-pointer disabled:opacity-50"
+            >
+              {isDeleting ? 'Deleting...' : isShared ? 'Remove' : 'Delete'}
+            </button>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/accounts/AccountCard.jsx
+++ b/frontend/src/components/accounts/AccountCard.jsx
@@ -1,0 +1,72 @@
+import { cn, formatCurrency } from '../../lib';
+import { BrokerLogo } from '../AccountWizard/BrokerLogo';
+import { TYPE_LABELS } from './constants';
+
+export function AccountCard({ account, holdings, currency, onClick }) {
+  const topHoldings = (holdings || []).slice(0, 3);
+  const remainingCount = (holdings || []).length - 3;
+
+  return (
+    <div
+      onClick={() => onClick(account)}
+      className={cn(
+        'bg-[var(--bg-secondary)] border border-[var(--border-primary)] rounded-xl',
+        'p-5 cursor-pointer transition-all flex flex-col gap-3.5',
+        'hover:border-[var(--accent-primary)] hover:shadow-[0_0_0_1px_var(--accent-primary)]'
+      )}
+    >
+      {/* Header: logo + name + type */}
+      <div className="flex items-center gap-3">
+        <BrokerLogo type={account.broker_type} className="w-10 h-10 rounded-[10px] shrink-0" />
+        <div className="min-w-0 flex-1">
+          <span className="text-[15px] font-semibold text-[var(--text-primary)]">
+            {account.name}
+          </span>
+          <span className="inline-block ml-2 px-2 py-0.5 rounded text-[10px] font-semibold uppercase tracking-wider bg-[var(--bg-tertiary)] text-[var(--text-tertiary)]">
+            {TYPE_LABELS[account.account_type] || account.account_type}
+          </span>
+        </div>
+      </div>
+
+      {/* Value row */}
+      <div className="flex items-baseline justify-between gap-2">
+        <span className="text-2xl font-bold font-mono tabular-nums tracking-tight">
+          {formatCurrency(account.value, currency, { decimals: 0 })}
+        </span>
+        <span className="text-[13px] font-semibold font-mono tabular-nums text-[var(--text-tertiary)]">
+          {account.allocationPct.toFixed(1)}%
+        </span>
+      </div>
+
+      {/* Holdings pills */}
+      {topHoldings.length > 0 && (
+        <div className="flex flex-wrap gap-1.5">
+          {topHoldings.map((h) => (
+            <div
+              key={h.symbol}
+              className="flex items-center gap-1 px-2.5 py-1 rounded-md text-[11px] font-medium bg-[var(--bg-tertiary)] text-[var(--text-secondary)] border border-[var(--border-subtle)]"
+            >
+              <span>{h.symbol}</span>
+              <span className="font-mono tabular-nums text-[10px] text-[var(--text-tertiary)]">
+                {formatCurrency(h.marketValue, currency, { decimals: 0 })}
+              </span>
+            </div>
+          ))}
+          {remainingCount > 0 && (
+            <div className="px-2 py-1 rounded-md text-[10px] font-semibold bg-[var(--blue-muted)] text-[var(--accent-primary)] border border-transparent">
+              +{remainingCount} more
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Footer: sync status */}
+      <div className="flex items-center pt-2.5 border-t border-[var(--border-subtle)]">
+        <div className="flex items-center gap-1.5 text-[11px] text-[var(--text-faint)]">
+          <div className={cn('w-1.5 h-1.5 rounded-full shrink-0', account.syncStatus.color)} />
+          Last synced {account.lastSyncFormatted}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/accounts/AccountGrid.jsx
+++ b/frontend/src/components/accounts/AccountGrid.jsx
@@ -1,7 +1,7 @@
 import { AccountCard } from './AccountCard';
 import { PlusIcon } from './icons';
 
-export function AccountGrid({ accounts, accountHoldings, currency, onCardClick, onAddAccount }) {
+export function AccountGrid({ accounts, accountHoldings, currency, onCardClick, onDelete, onAddAccount }) {
   return (
     <div className="grid grid-cols-[repeat(auto-fill,minmax(340px,1fr))] gap-4">
       {accounts.map((account) => (
@@ -11,6 +11,7 @@ export function AccountGrid({ accounts, accountHoldings, currency, onCardClick, 
           holdings={accountHoldings.get(account.id) || []}
           currency={currency}
           onClick={onCardClick}
+          onDelete={onDelete}
         />
       ))}
 

--- a/frontend/src/components/accounts/AccountGrid.jsx
+++ b/frontend/src/components/accounts/AccountGrid.jsx
@@ -1,0 +1,27 @@
+import { AccountCard } from './AccountCard';
+import { PlusIcon } from './icons';
+
+export function AccountGrid({ accounts, accountHoldings, currency, onCardClick, onAddAccount }) {
+  return (
+    <div className="grid grid-cols-[repeat(auto-fill,minmax(340px,1fr))] gap-4">
+      {accounts.map((account) => (
+        <AccountCard
+          key={account.id}
+          account={account}
+          holdings={accountHoldings.get(account.id) || []}
+          currency={currency}
+          onClick={onCardClick}
+        />
+      ))}
+
+      {/* Add Account placeholder card */}
+      <div
+        onClick={onAddAccount}
+        className="flex flex-col items-center justify-center gap-2.5 min-h-[200px] cursor-pointer border-2 border-dashed border-[var(--border-primary)] rounded-xl text-[var(--text-faint)] text-[13px] font-medium transition-all hover:border-[var(--accent-primary)] hover:text-[var(--accent-primary)] hover:bg-[var(--bg-secondary)]"
+      >
+        <PlusIcon className="w-6 h-6" />
+        Add Account
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/accounts/AccountSidebar.jsx
+++ b/frontend/src/components/accounts/AccountSidebar.jsx
@@ -1,9 +1,11 @@
+import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { cn, formatCurrency, formatPercent } from '../../lib';
 import { ASSET_COLORS } from '../../lib/constants';
 import { BrokerLogo } from '../AccountWizard/BrokerLogo';
+import { getBrokerConfig } from '../AccountWizard/constants/brokerConfig';
 import { useSlideover } from '../../hooks/useSlideover';
-import { ExternalLinkIcon, XMarkIcon } from './icons';
+import { ExternalLinkIcon, XMarkIcon, PencilSquareIcon, TrashIcon, CloudArrowUpIcon, KeyIcon } from './icons';
 import { TYPE_LABELS } from './constants';
 
 function pnlColor(value) {
@@ -30,16 +32,42 @@ function HoldingIcon({ symbol, assetClass }) {
   );
 }
 
-export function AccountSidebar({ account, holdings, currency, onClose }) {
+export function AccountSidebar({ account, holdings, currency, onClose, onDelete, onRename, onUpload, onApiCredentials, positionsTruncated }) {
   const isOpen = !!account;
   const navigate = useNavigate();
   useSlideover(isOpen, onClose);
 
+  const [editingName, setEditingName] = useState(false);
+  const [nameValue, setNameValue] = useState('');
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+
   if (!account) return null;
 
+  const brokerConfig = getBrokerConfig(account.broker_type);
   const totalCost = (holdings || []).reduce((s, h) => s + (h.costBasis || 0), 0);
   const totalPnl = (holdings || []).reduce((s, h) => s + (h.pnl || 0), 0);
   const totalPnlPct = totalCost > 0 ? (totalPnl / totalCost) * 100 : 0;
+
+  const startRename = () => {
+    setNameValue(account.name);
+    setEditingName(true);
+  };
+
+  const commitRename = () => {
+    const trimmed = nameValue.trim();
+    setEditingName(false);
+    if (trimmed && trimmed !== account.name) {
+      onRename?.(account.id, trimmed);
+    }
+  };
+
+  const handleDeleteConfirm = async () => {
+    setIsDeleting(true);
+    await onDelete?.(account.id);
+    setIsDeleting(false);
+    setShowDeleteConfirm(false);
+  };
 
   return (
     <>
@@ -67,7 +95,30 @@ export function AccountSidebar({ account, holdings, currency, onClose }) {
             <div className="min-w-0 flex-1">
               <div className="flex items-center gap-2.5 mb-1">
                 <BrokerLogo type={account.broker_type} className="w-9 h-9 rounded-[9px] shrink-0" />
-                <h2 className="text-xl font-semibold truncate">{account.name}</h2>
+                {editingName ? (
+                  <input
+                    autoFocus
+                    value={nameValue}
+                    onChange={(e) => setNameValue(e.target.value)}
+                    onBlur={commitRename}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter') commitRename();
+                      if (e.key === 'Escape') setEditingName(false);
+                    }}
+                    className="text-xl font-semibold bg-transparent border-b border-[var(--accent-primary)] outline-none w-full"
+                  />
+                ) : (
+                  <div className="flex items-center gap-1.5 min-w-0">
+                    <h2 className="text-xl font-semibold truncate">{account.name}</h2>
+                    <button
+                      onClick={startRename}
+                      className="shrink-0 w-6 h-6 flex items-center justify-center rounded text-[var(--text-faint)] hover:text-[var(--text-secondary)] hover:bg-[var(--bg-tertiary)] transition-all cursor-pointer"
+                      title="Rename account"
+                    >
+                      <PencilSquareIcon className="w-3.5 h-3.5" />
+                    </button>
+                  </div>
+                )}
               </div>
               <p className="text-[13px] text-[var(--text-faint)]">
                 {TYPE_LABELS[account.account_type] || account.account_type} Account
@@ -157,8 +208,63 @@ export function AccountSidebar({ account, holdings, currency, onClose }) {
                   </div>
                 </div>
               ))}
+              {positionsTruncated && (
+                <p className="text-[11px] text-[var(--text-faint)] mt-2 pt-2 border-t border-[var(--border-subtle)]">
+                  Portfolio has more than 100 positions. View full list in account details.
+                </p>
+              )}
             </div>
           )}
+
+          {/* Management actions */}
+          <div className="bg-[var(--bg-secondary)] border border-[var(--border-primary)] rounded-xl p-4">
+            <h3 className="text-[13px] font-semibold text-[var(--text-secondary)] mb-3">Manage</h3>
+            <div className="flex flex-col gap-2">
+              {brokerConfig?.supportedFormats?.length > 0 && (
+                <ActionButton
+                  icon={<CloudArrowUpIcon className="w-4 h-4" />}
+                  label="Upload Data"
+                  onClick={() => onUpload?.(account)}
+                />
+              )}
+              {brokerConfig?.hasApi && (
+                <ActionButton
+                  icon={<KeyIcon className="w-4 h-4" />}
+                  label="API Credentials"
+                  onClick={() => onApiCredentials?.(account)}
+                />
+              )}
+              {!showDeleteConfirm ? (
+                <ActionButton
+                  icon={<TrashIcon className="w-4 h-4" />}
+                  label="Delete Account"
+                  variant="danger"
+                  onClick={() => setShowDeleteConfirm(true)}
+                />
+              ) : (
+                <div className="p-3 rounded-lg bg-[var(--bg-tertiary)] border border-[var(--negative)]/30">
+                  <p className="text-[12px] text-[var(--text-secondary)] mb-2.5">
+                    Permanently delete this account and all its data?
+                  </p>
+                  <div className="flex gap-2">
+                    <button
+                      onClick={() => setShowDeleteConfirm(false)}
+                      className="flex-1 px-3 py-1.5 rounded-md text-xs font-medium bg-[var(--bg-primary)] border border-[var(--border-primary)] text-[var(--text-secondary)] hover:text-[var(--text-primary)] transition-colors cursor-pointer"
+                    >
+                      Cancel
+                    </button>
+                    <button
+                      onClick={handleDeleteConfirm}
+                      disabled={isDeleting}
+                      className="flex-1 px-3 py-1.5 rounded-md text-xs font-semibold bg-[var(--negative)] text-white hover:opacity-90 transition-opacity cursor-pointer disabled:opacity-50"
+                    >
+                      {isDeleting ? 'Deleting...' : 'Delete'}
+                    </button>
+                  </div>
+                </div>
+              )}
+            </div>
+          </div>
         </div>
       </div>
     </>
@@ -176,6 +282,24 @@ function DetailRow({ label, value, valueClass, isLast }) {
         {value}
       </span>
     </div>
+  );
+}
+
+function ActionButton({ icon, label, onClick, variant = 'default' }) {
+  const isDefault = variant === 'default';
+  return (
+    <button
+      onClick={onClick}
+      className={cn(
+        'flex items-center gap-2.5 w-full px-3 py-2.5 rounded-lg text-[13px] font-medium transition-colors cursor-pointer text-left',
+        isDefault
+          ? 'text-[var(--text-secondary)] hover:bg-[var(--bg-tertiary)] hover:text-[var(--text-primary)]'
+          : 'text-[var(--negative)] hover:bg-[var(--negative)]/10'
+      )}
+    >
+      {icon}
+      {label}
+    </button>
   );
 }
 

--- a/frontend/src/components/accounts/AccountSidebar.jsx
+++ b/frontend/src/components/accounts/AccountSidebar.jsx
@@ -3,9 +3,8 @@ import { useNavigate } from 'react-router-dom';
 import { cn, formatCurrency, formatPercent, api, transformTrade, transformDividend, transformForex, transformCash } from '../../lib';
 import { ASSET_COLORS } from '../../lib/constants';
 import { BrokerLogo } from '../AccountWizard/BrokerLogo';
-import { getBrokerConfig } from '../AccountWizard/constants/brokerConfig';
 import { useSlideover } from '../../hooks/useSlideover';
-import { ExternalLinkIcon, XMarkIcon, PencilSquareIcon, TrashIcon, CloudArrowUpIcon, KeyIcon } from './icons';
+import { ExternalLinkIcon, XMarkIcon, PencilSquareIcon, TrashIcon } from './icons';
 import { TYPE_LABELS } from './constants';
 
 const HOLDINGS_PREVIEW = 5;
@@ -79,7 +78,7 @@ async function fetchRecentActivity(accountId, currency) {
   return all.slice(0, 5);
 }
 
-export function AccountSidebar({ account, holdings, currency, onClose, onDelete, onRename, onUpload, onApiCredentials }) {
+export function AccountSidebar({ account, holdings, currency, onClose, onDelete, onRename }) {
   const isOpen = !!account;
   const navigate = useNavigate();
   useSlideover(isOpen, onClose);
@@ -129,7 +128,6 @@ export function AccountSidebar({ account, holdings, currency, onClose, onDelete,
 
   if (!renderAccount) return null;
 
-  const brokerConfig = getBrokerConfig(renderAccount.broker_type);
   const isShared = (renderAccount.portfolio_ids?.length ?? 0) > 1;
   const totalCost = (holdings || []).reduce((s, h) => s + (h.costBasis || 0), 0);
   const totalPnl = (holdings || []).reduce((s, h) => s + (h.pnl || 0), 0);
@@ -291,9 +289,7 @@ export function AccountSidebar({ account, holdings, currency, onClose, onDelete,
           {/* Holdings card — top 5 */}
           {visibleHoldings.length > 0 && (
             <div className="bg-[var(--bg-secondary)] border border-[var(--border-primary)] rounded-xl p-4">
-              <h3 className="text-[13px] font-semibold text-[var(--text-secondary)] mb-3">
-                Top Holdings ({(holdings || []).length})
-              </h3>
+              <h3 className="text-[13px] font-semibold text-[var(--text-secondary)] mb-3">Top Holdings</h3>
               {visibleHoldings.map((h) => (
                 <div
                   key={h.symbol}
@@ -318,13 +314,13 @@ export function AccountSidebar({ account, holdings, currency, onClose, onDelete,
                   </div>
                 </div>
               ))}
-              {(hiddenCount > 0 || renderAccount.holdingCount > (holdings || []).length) && (
-                <p className="text-[11px] text-[var(--text-faint)] mt-2 pt-2 border-t border-[var(--border-subtle)]">
-                  {renderAccount.holdingCount > (holdings || []).length
-                    ? `Showing ${(holdings || []).length} of ${renderAccount.holdingCount} positions. View full list in account details.`
-                    : `+${hiddenCount} more positions — view full list in account details.`}
-                </p>
-              )}
+              <button
+                onClick={() => navigate(`/accounts/${renderAccount.id}?tab=holdings`)}
+                className="mt-2 pt-2 border-t border-[var(--border-subtle)] w-full flex items-center justify-center gap-1.5 text-[12px] text-[var(--text-faint)] hover:text-[var(--accent-primary)] transition-colors cursor-pointer"
+              >
+                View all holdings
+                <ExternalLinkIcon className="w-3 h-3" />
+              </button>
             </div>
           )}
 
@@ -347,28 +343,37 @@ export function AccountSidebar({ account, holdings, currency, onClose, onDelete,
             ) : recentActivity.length === 0 ? (
               <p className="text-[12px] text-[var(--text-faint)]">No recent transactions.</p>
             ) : (
-              recentActivity.map((tx) => {
-                const style = TX_STYLES[tx.type] || TX_STYLES.cash;
-                return (
-                  <div
-                    key={tx.id}
-                    className="flex items-center justify-between py-2.5 border-b border-[var(--border-subtle)] last:border-b-0"
-                  >
-                    <div className="flex items-center gap-2.5">
-                      <div className={cn('w-7 h-7 rounded-md shrink-0 flex items-center justify-center text-[9px] font-bold', style.bg, style.text)}>
-                        {style.label}
+              <>
+                {recentActivity.map((tx) => {
+                  const style = TX_STYLES[tx.type] || TX_STYLES.cash;
+                  return (
+                    <div
+                      key={tx.id}
+                      className="flex items-center justify-between py-2.5 border-b border-[var(--border-subtle)] last:border-b-0"
+                    >
+                      <div className="flex items-center gap-2.5">
+                        <div className={cn('w-7 h-7 rounded-md shrink-0 flex items-center justify-center text-[9px] font-bold', style.bg, style.text)}>
+                          {style.label}
+                        </div>
+                        <div>
+                          <div className="text-[13px] font-medium text-[var(--text-primary)]">{txDescription(tx)}</div>
+                          <div className="text-[11px] text-[var(--text-faint)]">{formatDateShort(tx.date)}</div>
+                        </div>
                       </div>
-                      <div>
-                        <div className="text-[13px] font-medium text-[var(--text-primary)]">{txDescription(tx)}</div>
-                        <div className="text-[11px] text-[var(--text-faint)]">{formatDateShort(tx.date)}</div>
+                      <div className="text-[13px] font-mono tabular-nums text-[var(--text-secondary)]">
+                        {txAmount(tx, currency)}
                       </div>
                     </div>
-                    <div className="text-[13px] font-mono tabular-nums text-[var(--text-secondary)]">
-                      {txAmount(tx, currency)}
-                    </div>
-                  </div>
-                );
-              })
+                  );
+                })}
+                <button
+                  onClick={() => navigate(`/accounts/${renderAccount.id}?tab=transactions`)}
+                  className="mt-2 pt-2 border-t border-[var(--border-subtle)] w-full flex items-center justify-center gap-1.5 text-[12px] text-[var(--text-faint)] hover:text-[var(--accent-primary)] transition-colors cursor-pointer"
+                >
+                  View all activity
+                  <ExternalLinkIcon className="w-3 h-3" />
+                </button>
+              </>
             )}
           </div>
 
@@ -376,20 +381,6 @@ export function AccountSidebar({ account, holdings, currency, onClose, onDelete,
           <div className="bg-[var(--bg-secondary)] border border-[var(--border-primary)] rounded-xl p-4">
             <h3 className="text-[13px] font-semibold text-[var(--text-secondary)] mb-3">Manage</h3>
             <div className="flex flex-col gap-2">
-              {brokerConfig?.supportedFormats?.length > 0 && (
-                <ActionButton
-                  icon={<CloudArrowUpIcon className="w-4 h-4" />}
-                  label="Upload Data"
-                  onClick={() => onUpload?.(renderAccount)}
-                />
-              )}
-              {brokerConfig?.hasApi && (
-                <ActionButton
-                  icon={<KeyIcon className="w-4 h-4" />}
-                  label="API Credentials"
-                  onClick={() => onApiCredentials?.(renderAccount)}
-                />
-              )}
               {!showDeleteConfirm ? (
                 <ActionButton
                   icon={<TrashIcon className="w-4 h-4" />}

--- a/frontend/src/components/accounts/AccountSidebar.jsx
+++ b/frontend/src/components/accounts/AccountSidebar.jsx
@@ -1,0 +1,188 @@
+import { useNavigate } from 'react-router-dom';
+import { cn, formatCurrency, formatPercent } from '../../lib';
+import { ASSET_COLORS } from '../../lib/constants';
+import { BrokerLogo } from '../AccountWizard/BrokerLogo';
+import { useSlideover } from '../../hooks/useSlideover';
+import { ExternalLinkIcon, XMarkIcon } from './icons';
+import { TYPE_LABELS } from './constants';
+
+function pnlColor(value) {
+  if (value > 0) return 'text-[var(--positive)]';
+  if (value < 0) return 'text-[var(--negative)]';
+  return 'text-[var(--text-tertiary)]';
+}
+
+function formatPnl(value, currency) {
+  if (value === null || value === undefined) return '-';
+  const sign = value >= 0 ? '+' : '-';
+  return `${sign}${formatCurrency(Math.abs(value), currency, { decimals: 0 })}`;
+}
+
+function HoldingIcon({ symbol, assetClass }) {
+  const color = ASSET_COLORS[assetClass] || '#64748B';
+  return (
+    <div
+      className="w-7 h-7 rounded-md shrink-0 flex items-center justify-center text-[9px] font-bold text-white"
+      style={{ backgroundColor: color }}
+    >
+      {(symbol || '??').slice(0, 2)}
+    </div>
+  );
+}
+
+export function AccountSidebar({ account, holdings, currency, onClose }) {
+  const isOpen = !!account;
+  const navigate = useNavigate();
+  useSlideover(isOpen, onClose);
+
+  if (!account) return null;
+
+  const totalCost = (holdings || []).reduce((s, h) => s + (h.costBasis || 0), 0);
+  const totalPnl = (holdings || []).reduce((s, h) => s + (h.pnl || 0), 0);
+  const totalPnlPct = totalCost > 0 ? (totalPnl / totalCost) * 100 : 0;
+
+  return (
+    <>
+      {/* Backdrop */}
+      <div
+        className={cn(
+          'fixed inset-0 bg-black/50 z-[200] transition-opacity',
+          isOpen ? 'opacity-100' : 'opacity-0 pointer-events-none'
+        )}
+        onClick={onClose}
+      />
+
+      {/* Panel */}
+      <div
+        className={cn(
+          'fixed right-0 top-0 h-dvh w-[440px] max-w-[90vw] bg-[var(--bg-primary)]',
+          'border-l border-[var(--border-primary)] z-[201]',
+          'flex flex-col transition-transform duration-200 ease-out',
+          isOpen ? 'translate-x-0' : 'translate-x-full'
+        )}
+      >
+        {/* Header */}
+        <div className="px-6 py-5 border-b border-[var(--border-primary)] sticky top-0 bg-[var(--bg-primary)] z-10">
+          <div className="flex items-start justify-between gap-3">
+            <div className="min-w-0 flex-1">
+              <div className="flex items-center gap-2.5 mb-1">
+                <BrokerLogo type={account.broker_type} className="w-9 h-9 rounded-[9px] shrink-0" />
+                <h2 className="text-xl font-semibold truncate">{account.name}</h2>
+              </div>
+              <p className="text-[13px] text-[var(--text-faint)]">
+                {TYPE_LABELS[account.account_type] || account.account_type} Account
+                {' \u00B7 '}
+                {account.allocationPct.toFixed(1)}% of portfolio
+              </p>
+            </div>
+            <div className="flex items-center gap-2 shrink-0">
+              <button
+                onClick={() => navigate(`/accounts/${account.id}`)}
+                className="flex items-center gap-1.5 px-3 py-1.5 bg-[var(--accent-primary)] text-white rounded-lg text-xs font-semibold hover:bg-[var(--accent-hover)] transition-colors cursor-pointer whitespace-nowrap"
+              >
+                View Details
+                <ExternalLinkIcon className="w-3.5 h-3.5" />
+              </button>
+              <button
+                onClick={onClose}
+                className="w-8 h-8 flex items-center justify-center rounded-lg text-[var(--text-tertiary)] hover:bg-[var(--bg-tertiary)] hover:text-[var(--text-secondary)] transition-all cursor-pointer"
+              >
+                <XMarkIcon className="w-[18px] h-[18px]" />
+              </button>
+            </div>
+          </div>
+
+          {/* Value block */}
+          <div className="mt-3.5">
+            <span className="text-[28px] font-bold font-mono tabular-nums tracking-tight">
+              {formatCurrency(account.value, currency, { decimals: 0 })}
+            </span>
+            <span className={cn('text-sm font-medium font-mono tabular-nums ml-2.5', pnlColor(totalPnl))}>
+              {formatPnl(totalPnl, currency)} ({formatPercent(totalPnlPct)})
+            </span>
+          </div>
+        </div>
+
+        {/* Body */}
+        <div className="flex-1 overflow-y-auto px-6 py-5 flex flex-col gap-[18px]">
+          {/* Summary card */}
+          <div className="bg-[var(--bg-secondary)] border border-[var(--border-primary)] rounded-xl p-4">
+            <h3 className="text-[13px] font-semibold text-[var(--text-secondary)] mb-3">Summary</h3>
+            <DetailRow label="Total Cost" value={formatCurrency(totalCost, currency, { decimals: 0 })} />
+            <DetailRow
+              label="Unrealized P&L"
+              value={`${formatPnl(totalPnl, currency)} (${formatPercent(totalPnlPct)})`}
+              valueClass={pnlColor(totalPnl)}
+            />
+            <DetailRow label="Positions" value={String((holdings || []).length)} />
+            <DetailRow
+              label="Sync Status"
+              value={
+                <span className="flex items-center gap-1.5">
+                  <span className={cn('w-1.5 h-1.5 rounded-full inline-block', account.syncStatus.color)} />
+                  {account.lastSyncFormatted}
+                </span>
+              }
+              isLast
+            />
+          </div>
+
+          {/* Holdings card */}
+          {(holdings || []).length > 0 && (
+            <div className="bg-[var(--bg-secondary)] border border-[var(--border-primary)] rounded-xl p-4">
+              <h3 className="text-[13px] font-semibold text-[var(--text-secondary)] mb-3">
+                Holdings ({holdings.length})
+              </h3>
+              {holdings.map((h) => (
+                <div
+                  key={h.symbol}
+                  className="flex items-center justify-between py-2.5 border-b border-[var(--border-subtle)] last:border-b-0"
+                >
+                  <div className="flex items-center gap-2.5">
+                    <HoldingIcon symbol={h.symbol} assetClass={h.assetClass} />
+                    <div>
+                      <div className="text-[13px] font-semibold text-[var(--text-primary)]">{h.symbol}</div>
+                      <div className="text-[11px] text-[var(--text-faint)]">
+                        {formatQuantity(h.quantity, h.assetClass)} units
+                      </div>
+                    </div>
+                  </div>
+                  <div className="text-right">
+                    <div className="text-[13px] font-semibold font-mono tabular-nums text-[var(--text-primary)]">
+                      {formatCurrency(h.marketValue, currency, { decimals: 0 })}
+                    </div>
+                    <div className={cn('text-[11px] font-mono tabular-nums', pnlColor(h.pnl))}>
+                      {formatPnl(h.pnl, currency)}
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </>
+  );
+}
+
+function DetailRow({ label, value, valueClass, isLast }) {
+  return (
+    <div className={cn(
+      'flex items-center justify-between py-2',
+      !isLast && 'border-b border-[var(--border-subtle)]'
+    )}>
+      <span className="text-[13px] text-[var(--text-faint)]">{label}</span>
+      <span className={cn('text-[13px] font-medium text-[var(--text-primary)]', valueClass)}>
+        {value}
+      </span>
+    </div>
+  );
+}
+
+function formatQuantity(qty, assetClass) {
+  if (qty === null || qty === undefined) return '0';
+  if (assetClass === 'Crypto') {
+    return Number(qty).toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 4 });
+  }
+  return Number(qty).toLocaleString('en-US', { maximumFractionDigits: 0 });
+}

--- a/frontend/src/components/accounts/AccountSidebar.jsx
+++ b/frontend/src/components/accounts/AccountSidebar.jsx
@@ -4,7 +4,7 @@ import { cn, formatCurrency, formatPercent, api, transformTrade, transformDivide
 import { ASSET_COLORS } from '../../lib/constants';
 import { BrokerLogo } from '../AccountWizard/BrokerLogo';
 import { useSlideover } from '../../hooks/useSlideover';
-import { ExternalLinkIcon, XMarkIcon, PencilSquareIcon, TrashIcon } from './icons';
+import { ExternalLinkIcon, XMarkIcon, PencilSquareIcon } from './icons';
 import { TYPE_LABELS } from './constants';
 
 const HOLDINGS_PREVIEW = 5;
@@ -78,7 +78,7 @@ async function fetchRecentActivity(accountId, currency) {
   return all.slice(0, 5);
 }
 
-export function AccountSidebar({ account, holdings, currency, onClose, onDelete, onRename }) {
+export function AccountSidebar({ account, holdings, currency, onClose, onRename }) {
   const isOpen = !!account;
   const navigate = useNavigate();
   useSlideover(isOpen, onClose);
@@ -86,9 +86,6 @@ export function AccountSidebar({ account, holdings, currency, onClose, onDelete,
   const [editingName, setEditingName] = useState(false);
   const [nameValue, setNameValue] = useState('');
   const [renameError, setRenameError] = useState(null);
-  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
-  const [isDeleting, setIsDeleting] = useState(false);
-  const [deleteError, setDeleteError] = useState(null);
   const [recentActivity, setRecentActivity] = useState([]);
   const [activityLoading, setActivityLoading] = useState(false);
 
@@ -108,9 +105,6 @@ export function AccountSidebar({ account, holdings, currency, onClose, onDelete,
     setEditingName(false);
     setNameValue('');
     setRenameError(null);
-    setShowDeleteConfirm(false);
-    setIsDeleting(false);
-    setDeleteError(null);
     setRecentActivity([]);
   }, [account?.id]);
 
@@ -128,7 +122,6 @@ export function AccountSidebar({ account, holdings, currency, onClose, onDelete,
 
   if (!renderAccount) return null;
 
-  const isShared = (renderAccount.portfolio_ids?.length ?? 0) > 1;
   const totalCost = (holdings || []).reduce((s, h) => s + (h.costBasis || 0), 0);
   const totalPnl = (holdings || []).reduce((s, h) => s + (h.pnl || 0), 0);
   const totalPnlPct = totalCost > 0 ? (totalPnl / totalCost) * 100 : 0;
@@ -154,19 +147,6 @@ export function AccountSidebar({ account, holdings, currency, onClose, onDelete,
       } catch (err) {
         setRenameError(err.message || 'Failed to rename account');
       }
-    }
-  };
-
-  // Only resets spinner/error on the failure path — success closes the sidebar
-  // naturally via liveSelectedAccount becoming null in the parent.
-  const handleDeleteConfirm = async () => {
-    setIsDeleting(true);
-    setDeleteError(null);
-    try {
-      await onDelete?.(renderAccount.id);
-    } catch (err) {
-      setIsDeleting(false);
-      setDeleteError(err.message || 'Failed to delete account');
     }
   };
 
@@ -377,46 +357,6 @@ export function AccountSidebar({ account, holdings, currency, onClose, onDelete,
             )}
           </div>
 
-          {/* Management actions */}
-          <div className="bg-[var(--bg-secondary)] border border-[var(--border-primary)] rounded-xl p-4">
-            <h3 className="text-[13px] font-semibold text-[var(--text-secondary)] mb-3">Manage</h3>
-            <div className="flex flex-col gap-2">
-              {!showDeleteConfirm ? (
-                <ActionButton
-                  icon={<TrashIcon className="w-4 h-4" />}
-                  label={isShared ? 'Remove from Portfolio' : 'Delete Account'}
-                  variant="danger"
-                  onClick={() => setShowDeleteConfirm(true)}
-                />
-              ) : (
-                <div className="p-3 rounded-lg bg-[var(--bg-tertiary)] border border-[var(--negative)]/30">
-                  <p className="text-[12px] text-[var(--text-secondary)] mb-2.5">
-                    {isShared
-                      ? 'Remove this account from the current portfolio? It will remain in other portfolios.'
-                      : 'Permanently delete this account and all its data?'}
-                  </p>
-                  {deleteError && (
-                    <p className="text-[11px] text-[var(--negative)] mb-2">{deleteError}</p>
-                  )}
-                  <div className="flex gap-2">
-                    <button
-                      onClick={() => { setShowDeleteConfirm(false); setDeleteError(null); }}
-                      className="flex-1 px-3 py-1.5 rounded-md text-xs font-medium bg-[var(--bg-primary)] border border-[var(--border-primary)] text-[var(--text-secondary)] hover:text-[var(--text-primary)] transition-colors cursor-pointer"
-                    >
-                      Cancel
-                    </button>
-                    <button
-                      onClick={handleDeleteConfirm}
-                      disabled={isDeleting}
-                      className="flex-1 px-3 py-1.5 rounded-md text-xs font-semibold bg-[var(--negative)] text-white hover:opacity-90 transition-opacity cursor-pointer disabled:opacity-50"
-                    >
-                      {isDeleting ? 'Deleting...' : isShared ? 'Remove' : 'Delete'}
-                    </button>
-                  </div>
-                </div>
-              )}
-            </div>
-          </div>
         </div>
       </div>
     </>
@@ -437,23 +377,6 @@ function DetailRow({ label, value, valueClass, isLast }) {
   );
 }
 
-function ActionButton({ icon, label, onClick, variant = 'default' }) {
-  const isDefault = variant === 'default';
-  return (
-    <button
-      onClick={onClick}
-      className={cn(
-        'flex items-center gap-2.5 w-full px-3 py-2.5 rounded-lg text-[13px] font-medium transition-colors cursor-pointer text-left',
-        isDefault
-          ? 'text-[var(--text-secondary)] hover:bg-[var(--bg-tertiary)] hover:text-[var(--text-primary)]'
-          : 'text-[var(--negative)] hover:bg-[var(--negative)]/10'
-      )}
-    >
-      {icon}
-      {label}
-    </button>
-  );
-}
 
 function formatQuantity(qty, assetClass) {
   if (qty === null || qty === undefined) return '0';

--- a/frontend/src/components/accounts/AccountSidebar.jsx
+++ b/frontend/src/components/accounts/AccountSidebar.jsx
@@ -1,12 +1,14 @@
 import { useState, useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { cn, formatCurrency, formatPercent } from '../../lib';
+import { cn, formatCurrency, formatPercent, api, transformTrade, transformDividend, transformForex, transformCash } from '../../lib';
 import { ASSET_COLORS } from '../../lib/constants';
 import { BrokerLogo } from '../AccountWizard/BrokerLogo';
 import { getBrokerConfig } from '../AccountWizard/constants/brokerConfig';
 import { useSlideover } from '../../hooks/useSlideover';
 import { ExternalLinkIcon, XMarkIcon, PencilSquareIcon, TrashIcon, CloudArrowUpIcon, KeyIcon } from './icons';
 import { TYPE_LABELS } from './constants';
+
+const HOLDINGS_PREVIEW = 5;
 
 function pnlColor(value) {
   if (value > 0) return 'text-[var(--positive)]';
@@ -32,6 +34,51 @@ function HoldingIcon({ symbol, assetClass }) {
   );
 }
 
+const TX_STYLES = {
+  trade:    { label: 'Trade',    bg: 'bg-[var(--accent-primary)]/10', text: 'text-[var(--accent-primary)]' },
+  dividend: { label: 'Div',      bg: 'bg-[var(--positive)]/10',       text: 'text-[var(--positive)]' },
+  forex:    { label: 'FX',       bg: 'bg-[var(--warning)]/10',        text: 'text-[var(--warning)]' },
+  cash:     { label: 'Cash',     bg: 'bg-[var(--text-faint)]/10',     text: 'text-[var(--text-faint)]' },
+};
+
+function formatDateShort(dateStr) {
+  if (!dateStr) return '';
+  const d = new Date(dateStr);
+  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+}
+
+function txDescription(tx) {
+  if (tx.type === 'trade') return `${tx.side === 'BUY' ? 'Buy' : 'Sell'} ${tx.symbol}`;
+  if (tx.type === 'dividend') return `${tx.symbol} dividend`;
+  if (tx.type === 'forex') return 'FX conversion';
+  return tx.subtype || tx.type;
+}
+
+function txAmount(tx, currency) {
+  const value = tx.type === 'trade' ? tx.total : tx.amount;
+  if (value == null) return '-';
+  const prefix = tx.type === 'trade' && tx.side === 'BUY' ? '-' : '+';
+  return `${prefix}${formatCurrency(Math.abs(value), tx.currency || currency, { decimals: 0 })}`;
+}
+
+async function fetchRecentActivity(accountId, currency) {
+  const q = `?account_id=${accountId}&limit=5&display_currency=${currency}`;
+  const [trades, dividends, forex, cash] = await Promise.all([
+    api(`/transactions/trades${q}`).then((r) => r.ok ? r.json() : { items: [] }),
+    api(`/transactions/dividends${q}`).then((r) => r.ok ? r.json() : { items: [] }),
+    api(`/transactions/forex${q}`).then((r) => r.ok ? r.json() : { items: [] }),
+    api(`/transactions/cash${q}`).then((r) => r.ok ? r.json() : { items: [] }),
+  ]);
+  const all = [
+    ...trades.items.map(transformTrade),
+    ...dividends.items.map(transformDividend),
+    ...forex.items.map(transformForex),
+    ...cash.items.map(transformCash),
+  ];
+  all.sort((a, b) => new Date(b.date) - new Date(a.date));
+  return all.slice(0, 5);
+}
+
 export function AccountSidebar({ account, holdings, currency, onClose, onDelete, onRename, onUpload, onApiCredentials }) {
   const isOpen = !!account;
   const navigate = useNavigate();
@@ -43,6 +90,8 @@ export function AccountSidebar({ account, holdings, currency, onClose, onDelete,
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
   const [deleteError, setDeleteError] = useState(null);
+  const [recentActivity, setRecentActivity] = useState([]);
+  const [activityLoading, setActivityLoading] = useState(false);
 
   // Keep the last non-null account in a ref so the sidebar content remains
   // visible during the CSS slide-out animation (200ms) after account becomes null.
@@ -63,7 +112,20 @@ export function AccountSidebar({ account, holdings, currency, onClose, onDelete,
     setShowDeleteConfirm(false);
     setIsDeleting(false);
     setDeleteError(null);
+    setRecentActivity([]);
   }, [account?.id]);
+
+  // Fetch recent activity lazily when an account is selected.
+  useEffect(() => {
+    if (!account?.id) return;
+    let cancelled = false;
+    setActivityLoading(true);
+    fetchRecentActivity(account.id, currency)
+      .then((txs) => { if (!cancelled) setRecentActivity(txs); })
+      .catch(() => { if (!cancelled) setRecentActivity([]); })
+      .finally(() => { if (!cancelled) setActivityLoading(false); });
+    return () => { cancelled = true; };
+  }, [account?.id, currency]);
 
   if (!renderAccount) return null;
 
@@ -72,6 +134,8 @@ export function AccountSidebar({ account, holdings, currency, onClose, onDelete,
   const totalCost = (holdings || []).reduce((s, h) => s + (h.costBasis || 0), 0);
   const totalPnl = (holdings || []).reduce((s, h) => s + (h.pnl || 0), 0);
   const totalPnlPct = totalCost > 0 ? (totalPnl / totalCost) * 100 : 0;
+  const visibleHoldings = (holdings || []).slice(0, HOLDINGS_PREVIEW);
+  const hiddenCount = (holdings || []).length - visibleHoldings.length;
 
   const startRename = () => {
     setNameValue(renderAccount.name);
@@ -130,72 +194,73 @@ export function AccountSidebar({ account, holdings, currency, onClose, onDelete,
       >
         {/* Header */}
         <div className="px-6 py-5 border-b border-[var(--border-primary)] sticky top-0 bg-[var(--bg-primary)] z-10">
-          <div className="flex items-start justify-between gap-3">
-            <div className="min-w-0 flex-1">
-              <div className="flex items-center gap-2.5 mb-1">
-                <BrokerLogo type={renderAccount.broker_type} className="w-9 h-9 rounded-[9px] shrink-0" />
-                {editingName ? (
-                  <input
-                    autoFocus
-                    value={nameValue}
-                    onChange={(e) => setNameValue(e.target.value)}
-                    onBlur={commitRename}
-                    onKeyDown={(e) => {
-                      if (e.key === 'Enter') commitRename();
-                      if (e.key === 'Escape') {
-                        cancelRenameRef.current = true;
-                        setEditingName(false);
-                      }
-                    }}
-                    className="text-xl font-semibold bg-transparent border-b border-[var(--accent-primary)] outline-none w-full"
-                  />
-                ) : (
-                  <div className="flex items-center gap-1.5 min-w-0">
-                    <h2 className="text-xl font-semibold truncate">{renderAccount.name}</h2>
-                    <button
-                      onClick={startRename}
-                      className="shrink-0 w-6 h-6 flex items-center justify-center rounded text-[var(--text-faint)] hover:text-[var(--text-secondary)] hover:bg-[var(--bg-tertiary)] transition-all cursor-pointer"
-                      title="Rename account"
-                    >
-                      <PencilSquareIcon className="w-3.5 h-3.5" />
-                    </button>
-                  </div>
-                )}
-              </div>
-              <p className="text-[13px] text-[var(--text-faint)]">
-                {TYPE_LABELS[renderAccount.account_type] || renderAccount.account_type} Account
-                {' \u00B7 '}
-                {renderAccount.allocationPct.toFixed(1)}% of portfolio
-              </p>
-              {renameError && (
-                <p className="text-[11px] text-[var(--negative)] mt-0.5">{renameError}</p>
+          {/* Close button — absolute so it doesn't compete with the account name */}
+          <button
+            onClick={onClose}
+            className="absolute top-4 right-5 w-8 h-8 flex items-center justify-center rounded-lg text-[var(--text-tertiary)] hover:bg-[var(--bg-tertiary)] hover:text-[var(--text-secondary)] transition-all cursor-pointer"
+          >
+            <XMarkIcon className="w-[18px] h-[18px]" />
+          </button>
+
+          {/* Name row — full width minus space for close button */}
+          <div className="pr-10">
+            <div className="flex items-center gap-2.5 mb-1">
+              <BrokerLogo type={renderAccount.broker_type} className="w-9 h-9 rounded-[9px] shrink-0" />
+              {editingName ? (
+                <input
+                  autoFocus
+                  value={nameValue}
+                  onChange={(e) => setNameValue(e.target.value)}
+                  onBlur={commitRename}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') commitRename();
+                    if (e.key === 'Escape') {
+                      cancelRenameRef.current = true;
+                      setEditingName(false);
+                    }
+                  }}
+                  className="text-xl font-semibold bg-transparent border-b border-[var(--accent-primary)] outline-none w-full"
+                />
+              ) : (
+                <div className="flex items-center gap-1.5 min-w-0">
+                  <h2 className="text-xl font-semibold truncate">{renderAccount.name}</h2>
+                  <button
+                    onClick={startRename}
+                    className="shrink-0 w-6 h-6 flex items-center justify-center rounded text-[var(--text-faint)] hover:text-[var(--text-secondary)] hover:bg-[var(--bg-tertiary)] transition-all cursor-pointer"
+                    title="Rename account"
+                  >
+                    <PencilSquareIcon className="w-3.5 h-3.5" />
+                  </button>
+                </div>
               )}
             </div>
-            <div className="flex items-center gap-2 shrink-0">
-              <button
-                onClick={() => navigate(`/accounts/${renderAccount.id}`)}
-                className="flex items-center gap-1.5 px-3 py-1.5 bg-[var(--accent-primary)] text-white rounded-lg text-xs font-semibold hover:bg-[var(--accent-hover)] transition-colors cursor-pointer whitespace-nowrap"
-              >
-                View Details
-                <ExternalLinkIcon className="w-3.5 h-3.5" />
-              </button>
-              <button
-                onClick={onClose}
-                className="w-8 h-8 flex items-center justify-center rounded-lg text-[var(--text-tertiary)] hover:bg-[var(--bg-tertiary)] hover:text-[var(--text-secondary)] transition-all cursor-pointer"
-              >
-                <XMarkIcon className="w-[18px] h-[18px]" />
-              </button>
-            </div>
+            <p className="text-[13px] text-[var(--text-faint)]">
+              {TYPE_LABELS[renderAccount.account_type] || renderAccount.account_type} Account
+              {' \u00B7 '}
+              {renderAccount.allocationPct.toFixed(1)}% of portfolio
+            </p>
+            {renameError && (
+              <p className="text-[11px] text-[var(--negative)] mt-0.5">{renameError}</p>
+            )}
           </div>
 
-          {/* Value block */}
-          <div className="mt-3.5">
-            <span className="text-[28px] font-bold font-mono tabular-nums tracking-tight">
-              {formatCurrency(renderAccount.value, currency, { decimals: 0 })}
-            </span>
-            <span className={cn('text-sm font-medium font-mono tabular-nums ml-2.5', pnlColor(totalPnl))}>
-              {formatPnl(totalPnl, currency)} ({formatPercent(totalPnlPct)})
-            </span>
+          {/* Value block + View Details */}
+          <div className="mt-3.5 flex items-end justify-between gap-3">
+            <div>
+              <span className="text-[28px] font-bold font-mono tabular-nums tracking-tight">
+                {formatCurrency(renderAccount.value, currency, { decimals: 0 })}
+              </span>
+              <span className={cn('text-sm font-medium font-mono tabular-nums ml-2.5', pnlColor(totalPnl))}>
+                {formatPnl(totalPnl, currency)} ({formatPercent(totalPnlPct)})
+              </span>
+            </div>
+            <button
+              onClick={() => navigate(`/accounts/${renderAccount.id}`)}
+              className="shrink-0 flex items-center gap-1.5 px-3 py-1.5 bg-[var(--accent-primary)] text-white rounded-lg text-xs font-semibold hover:bg-[var(--accent-hover)] transition-colors cursor-pointer whitespace-nowrap"
+            >
+              View Details
+              <ExternalLinkIcon className="w-3.5 h-3.5" />
+            </button>
           </div>
         </div>
 
@@ -223,13 +288,13 @@ export function AccountSidebar({ account, holdings, currency, onClose, onDelete,
             />
           </div>
 
-          {/* Holdings card */}
-          {(holdings || []).length > 0 && (
+          {/* Holdings card — top 5 */}
+          {visibleHoldings.length > 0 && (
             <div className="bg-[var(--bg-secondary)] border border-[var(--border-primary)] rounded-xl p-4">
               <h3 className="text-[13px] font-semibold text-[var(--text-secondary)] mb-3">
-                Holdings ({holdings.length})
+                Top Holdings ({(holdings || []).length})
               </h3>
-              {holdings.map((h) => (
+              {visibleHoldings.map((h) => (
                 <div
                   key={h.symbol}
                   className="flex items-center justify-between py-2.5 border-b border-[var(--border-subtle)] last:border-b-0"
@@ -253,13 +318,59 @@ export function AccountSidebar({ account, holdings, currency, onClose, onDelete,
                   </div>
                 </div>
               ))}
-              {renderAccount.holdingCount > (holdings || []).length && (
+              {(hiddenCount > 0 || renderAccount.holdingCount > (holdings || []).length) && (
                 <p className="text-[11px] text-[var(--text-faint)] mt-2 pt-2 border-t border-[var(--border-subtle)]">
-                  Showing {(holdings || []).length} of {renderAccount.holdingCount} positions. View full list in account details.
+                  {renderAccount.holdingCount > (holdings || []).length
+                    ? `Showing ${(holdings || []).length} of ${renderAccount.holdingCount} positions. View full list in account details.`
+                    : `+${hiddenCount} more positions — view full list in account details.`}
                 </p>
               )}
             </div>
           )}
+
+          {/* Recent activity card */}
+          <div className="bg-[var(--bg-secondary)] border border-[var(--border-primary)] rounded-xl p-4">
+            <h3 className="text-[13px] font-semibold text-[var(--text-secondary)] mb-3">Recent Activity</h3>
+            {activityLoading ? (
+              <div className="flex flex-col gap-2.5">
+                {[1, 2, 3].map((i) => (
+                  <div key={i} className="flex items-center gap-2.5 py-1">
+                    <div className="w-7 h-7 rounded-md bg-[var(--bg-tertiary)] animate-pulse shrink-0" />
+                    <div className="flex-1 space-y-1.5">
+                      <div className="h-3 w-32 rounded bg-[var(--bg-tertiary)] animate-pulse" />
+                      <div className="h-2.5 w-16 rounded bg-[var(--bg-tertiary)] animate-pulse" />
+                    </div>
+                    <div className="h-3 w-16 rounded bg-[var(--bg-tertiary)] animate-pulse" />
+                  </div>
+                ))}
+              </div>
+            ) : recentActivity.length === 0 ? (
+              <p className="text-[12px] text-[var(--text-faint)]">No recent transactions.</p>
+            ) : (
+              recentActivity.map((tx) => {
+                const style = TX_STYLES[tx.type] || TX_STYLES.cash;
+                return (
+                  <div
+                    key={tx.id}
+                    className="flex items-center justify-between py-2.5 border-b border-[var(--border-subtle)] last:border-b-0"
+                  >
+                    <div className="flex items-center gap-2.5">
+                      <div className={cn('w-7 h-7 rounded-md shrink-0 flex items-center justify-center text-[9px] font-bold', style.bg, style.text)}>
+                        {style.label}
+                      </div>
+                      <div>
+                        <div className="text-[13px] font-medium text-[var(--text-primary)]">{txDescription(tx)}</div>
+                        <div className="text-[11px] text-[var(--text-faint)]">{formatDateShort(tx.date)}</div>
+                      </div>
+                    </div>
+                    <div className="text-[13px] font-mono tabular-nums text-[var(--text-secondary)]">
+                      {txAmount(tx, currency)}
+                    </div>
+                  </div>
+                );
+              })
+            )}
+          </div>
 
           {/* Management actions */}
           <div className="bg-[var(--bg-secondary)] border border-[var(--border-primary)] rounded-xl p-4">

--- a/frontend/src/components/accounts/AccountSidebar.jsx
+++ b/frontend/src/components/accounts/AccountSidebar.jsx
@@ -32,7 +32,7 @@ function HoldingIcon({ symbol, assetClass }) {
   );
 }
 
-export function AccountSidebar({ account, holdings, currency, onClose, onDelete, onRename, onUpload, onApiCredentials, positionsTruncated }) {
+export function AccountSidebar({ account, holdings, currency, onClose, onDelete, onRename, onUpload, onApiCredentials }) {
   const isOpen = !!account;
   const navigate = useNavigate();
   useSlideover(isOpen, onClose);
@@ -253,9 +253,9 @@ export function AccountSidebar({ account, holdings, currency, onClose, onDelete,
                   </div>
                 </div>
               ))}
-              {positionsTruncated && (
+              {renderAccount.holdingCount > (holdings || []).length && (
                 <p className="text-[11px] text-[var(--text-faint)] mt-2 pt-2 border-t border-[var(--border-subtle)]">
-                  Portfolio has more than 100 positions. View full list in account details.
+                  Showing {(holdings || []).length} of {renderAccount.holdingCount} positions. View full list in account details.
                 </p>
               )}
             </div>

--- a/frontend/src/components/accounts/AccountSidebar.jsx
+++ b/frontend/src/components/accounts/AccountSidebar.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { cn, formatCurrency, formatPercent } from '../../lib';
 import { ASSET_COLORS } from '../../lib/constants';
@@ -44,16 +44,34 @@ export function AccountSidebar({ account, holdings, currency, onClose, onDelete,
   const [isDeleting, setIsDeleting] = useState(false);
   const [deleteError, setDeleteError] = useState(null);
 
-  if (!account) return null;
+  // Keep the last non-null account in a ref so the sidebar content remains
+  // visible during the CSS slide-out animation (200ms) after account becomes null.
+  const prevAccountRef = useRef(account);
+  if (account) prevAccountRef.current = account;
+  const renderAccount = account ?? prevAccountRef.current;
 
-  const brokerConfig = getBrokerConfig(account.broker_type);
-  const isShared = (account.portfolio_ids?.length ?? 0) > 1;
+  // Reset all local state when switching to a different account.
+  // The null guard prevents resetting during the close animation.
+  useEffect(() => {
+    if (!account) return;
+    setEditingName(false);
+    setNameValue('');
+    setRenameError(null);
+    setShowDeleteConfirm(false);
+    setIsDeleting(false);
+    setDeleteError(null);
+  }, [account?.id]);
+
+  if (!renderAccount) return null;
+
+  const brokerConfig = getBrokerConfig(renderAccount.broker_type);
+  const isShared = (renderAccount.portfolio_ids?.length ?? 0) > 1;
   const totalCost = (holdings || []).reduce((s, h) => s + (h.costBasis || 0), 0);
   const totalPnl = (holdings || []).reduce((s, h) => s + (h.pnl || 0), 0);
   const totalPnlPct = totalCost > 0 ? (totalPnl / totalCost) * 100 : 0;
 
   const startRename = () => {
-    setNameValue(account.name);
+    setNameValue(renderAccount.name);
     setRenameError(null);
     setEditingName(true);
   };
@@ -61,9 +79,9 @@ export function AccountSidebar({ account, holdings, currency, onClose, onDelete,
   const commitRename = async () => {
     const trimmed = nameValue.trim();
     setEditingName(false);
-    if (trimmed && trimmed !== account.name) {
+    if (trimmed && trimmed !== renderAccount.name) {
       try {
-        await onRename?.(account.id, trimmed);
+        await onRename?.(renderAccount.id, trimmed);
       } catch (err) {
         setRenameError(err.message || 'Failed to rename account');
       }
@@ -76,7 +94,7 @@ export function AccountSidebar({ account, holdings, currency, onClose, onDelete,
     setIsDeleting(true);
     setDeleteError(null);
     try {
-      await onDelete?.(account.id);
+      await onDelete?.(renderAccount.id);
     } catch (err) {
       setIsDeleting(false);
       setDeleteError(err.message || 'Failed to delete account');
@@ -108,7 +126,7 @@ export function AccountSidebar({ account, holdings, currency, onClose, onDelete,
           <div className="flex items-start justify-between gap-3">
             <div className="min-w-0 flex-1">
               <div className="flex items-center gap-2.5 mb-1">
-                <BrokerLogo type={account.broker_type} className="w-9 h-9 rounded-[9px] shrink-0" />
+                <BrokerLogo type={renderAccount.broker_type} className="w-9 h-9 rounded-[9px] shrink-0" />
                 {editingName ? (
                   <input
                     autoFocus
@@ -123,7 +141,7 @@ export function AccountSidebar({ account, holdings, currency, onClose, onDelete,
                   />
                 ) : (
                   <div className="flex items-center gap-1.5 min-w-0">
-                    <h2 className="text-xl font-semibold truncate">{account.name}</h2>
+                    <h2 className="text-xl font-semibold truncate">{renderAccount.name}</h2>
                     <button
                       onClick={startRename}
                       className="shrink-0 w-6 h-6 flex items-center justify-center rounded text-[var(--text-faint)] hover:text-[var(--text-secondary)] hover:bg-[var(--bg-tertiary)] transition-all cursor-pointer"
@@ -135,9 +153,9 @@ export function AccountSidebar({ account, holdings, currency, onClose, onDelete,
                 )}
               </div>
               <p className="text-[13px] text-[var(--text-faint)]">
-                {TYPE_LABELS[account.account_type] || account.account_type} Account
+                {TYPE_LABELS[renderAccount.account_type] || renderAccount.account_type} Account
                 {' \u00B7 '}
-                {account.allocationPct.toFixed(1)}% of portfolio
+                {renderAccount.allocationPct.toFixed(1)}% of portfolio
               </p>
               {renameError && (
                 <p className="text-[11px] text-[var(--negative)] mt-0.5">{renameError}</p>
@@ -145,7 +163,7 @@ export function AccountSidebar({ account, holdings, currency, onClose, onDelete,
             </div>
             <div className="flex items-center gap-2 shrink-0">
               <button
-                onClick={() => navigate(`/accounts/${account.id}`)}
+                onClick={() => navigate(`/accounts/${renderAccount.id}`)}
                 className="flex items-center gap-1.5 px-3 py-1.5 bg-[var(--accent-primary)] text-white rounded-lg text-xs font-semibold hover:bg-[var(--accent-hover)] transition-colors cursor-pointer whitespace-nowrap"
               >
                 View Details
@@ -163,7 +181,7 @@ export function AccountSidebar({ account, holdings, currency, onClose, onDelete,
           {/* Value block */}
           <div className="mt-3.5">
             <span className="text-[28px] font-bold font-mono tabular-nums tracking-tight">
-              {formatCurrency(account.value, currency, { decimals: 0 })}
+              {formatCurrency(renderAccount.value, currency, { decimals: 0 })}
             </span>
             <span className={cn('text-sm font-medium font-mono tabular-nums ml-2.5', pnlColor(totalPnl))}>
               {formatPnl(totalPnl, currency)} ({formatPercent(totalPnlPct)})
@@ -187,8 +205,8 @@ export function AccountSidebar({ account, holdings, currency, onClose, onDelete,
               label="Sync Status"
               value={
                 <span className="flex items-center gap-1.5">
-                  <span className={cn('w-1.5 h-1.5 rounded-full inline-block', account.syncStatus.color)} />
-                  {account.lastSyncFormatted}
+                  <span className={cn('w-1.5 h-1.5 rounded-full inline-block', renderAccount.syncStatus.color)} />
+                  {renderAccount.lastSyncFormatted}
                 </span>
               }
               isLast
@@ -241,14 +259,14 @@ export function AccountSidebar({ account, holdings, currency, onClose, onDelete,
                 <ActionButton
                   icon={<CloudArrowUpIcon className="w-4 h-4" />}
                   label="Upload Data"
-                  onClick={() => onUpload?.(account)}
+                  onClick={() => onUpload?.(renderAccount)}
                 />
               )}
               {brokerConfig?.hasApi && (
                 <ActionButton
                   icon={<KeyIcon className="w-4 h-4" />}
                   label="API Credentials"
-                  onClick={() => onApiCredentials?.(account)}
+                  onClick={() => onApiCredentials?.(renderAccount)}
                 />
               )}
               {!showDeleteConfirm ? (

--- a/frontend/src/components/accounts/AccountSidebar.jsx
+++ b/frontend/src/components/accounts/AccountSidebar.jsx
@@ -39,34 +39,48 @@ export function AccountSidebar({ account, holdings, currency, onClose, onDelete,
 
   const [editingName, setEditingName] = useState(false);
   const [nameValue, setNameValue] = useState('');
+  const [renameError, setRenameError] = useState(null);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
+  const [deleteError, setDeleteError] = useState(null);
 
   if (!account) return null;
 
   const brokerConfig = getBrokerConfig(account.broker_type);
+  const isShared = (account.portfolio_ids?.length ?? 0) > 1;
   const totalCost = (holdings || []).reduce((s, h) => s + (h.costBasis || 0), 0);
   const totalPnl = (holdings || []).reduce((s, h) => s + (h.pnl || 0), 0);
   const totalPnlPct = totalCost > 0 ? (totalPnl / totalCost) * 100 : 0;
 
   const startRename = () => {
     setNameValue(account.name);
+    setRenameError(null);
     setEditingName(true);
   };
 
-  const commitRename = () => {
+  const commitRename = async () => {
     const trimmed = nameValue.trim();
     setEditingName(false);
     if (trimmed && trimmed !== account.name) {
-      onRename?.(account.id, trimmed);
+      try {
+        await onRename?.(account.id, trimmed);
+      } catch (err) {
+        setRenameError(err.message || 'Failed to rename account');
+      }
     }
   };
 
+  // Only resets spinner/error on the failure path — success closes the sidebar
+  // naturally via liveSelectedAccount becoming null in the parent.
   const handleDeleteConfirm = async () => {
     setIsDeleting(true);
-    await onDelete?.(account.id);
-    setIsDeleting(false);
-    setShowDeleteConfirm(false);
+    setDeleteError(null);
+    try {
+      await onDelete?.(account.id);
+    } catch (err) {
+      setIsDeleting(false);
+      setDeleteError(err.message || 'Failed to delete account');
+    }
   };
 
   return (
@@ -125,6 +139,9 @@ export function AccountSidebar({ account, holdings, currency, onClose, onDelete,
                 {' \u00B7 '}
                 {account.allocationPct.toFixed(1)}% of portfolio
               </p>
+              {renameError && (
+                <p className="text-[11px] text-[var(--negative)] mt-0.5">{renameError}</p>
+              )}
             </div>
             <div className="flex items-center gap-2 shrink-0">
               <button
@@ -237,18 +254,23 @@ export function AccountSidebar({ account, holdings, currency, onClose, onDelete,
               {!showDeleteConfirm ? (
                 <ActionButton
                   icon={<TrashIcon className="w-4 h-4" />}
-                  label="Delete Account"
+                  label={isShared ? 'Remove from Portfolio' : 'Delete Account'}
                   variant="danger"
                   onClick={() => setShowDeleteConfirm(true)}
                 />
               ) : (
                 <div className="p-3 rounded-lg bg-[var(--bg-tertiary)] border border-[var(--negative)]/30">
                   <p className="text-[12px] text-[var(--text-secondary)] mb-2.5">
-                    Permanently delete this account and all its data?
+                    {isShared
+                      ? 'Remove this account from the current portfolio? It will remain in other portfolios.'
+                      : 'Permanently delete this account and all its data?'}
                   </p>
+                  {deleteError && (
+                    <p className="text-[11px] text-[var(--negative)] mb-2">{deleteError}</p>
+                  )}
                   <div className="flex gap-2">
                     <button
-                      onClick={() => setShowDeleteConfirm(false)}
+                      onClick={() => { setShowDeleteConfirm(false); setDeleteError(null); }}
                       className="flex-1 px-3 py-1.5 rounded-md text-xs font-medium bg-[var(--bg-primary)] border border-[var(--border-primary)] text-[var(--text-secondary)] hover:text-[var(--text-primary)] transition-colors cursor-pointer"
                     >
                       Cancel
@@ -258,7 +280,7 @@ export function AccountSidebar({ account, holdings, currency, onClose, onDelete,
                       disabled={isDeleting}
                       className="flex-1 px-3 py-1.5 rounded-md text-xs font-semibold bg-[var(--negative)] text-white hover:opacity-90 transition-opacity cursor-pointer disabled:opacity-50"
                     >
-                      {isDeleting ? 'Deleting...' : 'Delete'}
+                      {isDeleting ? 'Deleting...' : isShared ? 'Remove' : 'Delete'}
                     </button>
                   </div>
                 </div>

--- a/frontend/src/components/accounts/AccountSidebar.jsx
+++ b/frontend/src/components/accounts/AccountSidebar.jsx
@@ -193,6 +193,7 @@ export function AccountSidebar({ account, holdings, currency, onClose, onRename 
                   onKeyDown={(e) => {
                     if (e.key === 'Enter') commitRename();
                     if (e.key === 'Escape') {
+                      e.stopPropagation();
                       cancelRenameRef.current = true;
                       setEditingName(false);
                     }

--- a/frontend/src/components/accounts/AccountSidebar.jsx
+++ b/frontend/src/components/accounts/AccountSidebar.jsx
@@ -50,6 +50,9 @@ export function AccountSidebar({ account, holdings, currency, onClose, onDelete,
   if (account) prevAccountRef.current = account;
   const renderAccount = account ?? prevAccountRef.current;
 
+  // Set to true when Escape is pressed so the blur handler skips commitRename.
+  const cancelRenameRef = useRef(false);
+
   // Reset all local state when switching to a different account.
   // The null guard prevents resetting during the close animation.
   useEffect(() => {
@@ -77,6 +80,10 @@ export function AccountSidebar({ account, holdings, currency, onClose, onDelete,
   };
 
   const commitRename = async () => {
+    if (cancelRenameRef.current) {
+      cancelRenameRef.current = false;
+      return;
+    }
     const trimmed = nameValue.trim();
     setEditingName(false);
     if (trimmed && trimmed !== renderAccount.name) {
@@ -135,7 +142,10 @@ export function AccountSidebar({ account, holdings, currency, onClose, onDelete,
                     onBlur={commitRename}
                     onKeyDown={(e) => {
                       if (e.key === 'Enter') commitRename();
-                      if (e.key === 'Escape') setEditingName(false);
+                      if (e.key === 'Escape') {
+                        cancelRenameRef.current = true;
+                        setEditingName(false);
+                      }
                     }}
                     className="text-xl font-semibold bg-transparent border-b border-[var(--accent-primary)] outline-none w-full"
                   />

--- a/frontend/src/components/accounts/AllocationStrip.jsx
+++ b/frontend/src/components/accounts/AllocationStrip.jsx
@@ -1,0 +1,80 @@
+import { formatCurrency } from '../../lib';
+import { Skeleton } from '../ui';
+
+const BROKER_COLORS = {
+  ibkr: '#E31937',
+  meitav: '#2563EB',
+  kraken: '#7B61FF',
+  bit2c: '#F7931A',
+  binance: '#F0B90B',
+};
+
+function getBrokerColor(brokerType) {
+  return BROKER_COLORS[brokerType] || 'var(--text-tertiary)';
+}
+
+export function AllocationStrip({ accounts, totalValue, currency, loading }) {
+  if (loading) {
+    return (
+      <div className="bg-[var(--bg-secondary)] border border-[var(--border-primary)] rounded-xl p-4 mb-5">
+        <div className="flex items-center justify-between mb-3">
+          <Skeleton className="h-4 w-32" />
+          <Skeleton className="h-5 w-24" />
+        </div>
+        <Skeleton className="h-2 w-full rounded-full" />
+        <div className="flex gap-2 mt-2.5">
+          {[1, 2, 3].map((i) => <Skeleton key={i} className="h-7 w-24 rounded-md" />)}
+        </div>
+      </div>
+    );
+  }
+
+  if (!accounts || accounts.length === 0) return null;
+
+  return (
+    <div className="bg-[var(--bg-secondary)] border border-[var(--border-primary)] rounded-xl p-4 mb-5">
+      <div className="flex items-center justify-between mb-3">
+        <span className="text-[13px] font-semibold text-[var(--text-secondary)]">
+          Portfolio Allocation
+        </span>
+        <span className="text-base font-bold font-mono tabular-nums">
+          {formatCurrency(totalValue, currency, { decimals: 0 })}
+        </span>
+      </div>
+
+      {/* Stacked bar */}
+      <div className="flex h-2 rounded-full overflow-hidden gap-0.5">
+        {accounts.map((acct) => (
+          <div
+            key={acct.id}
+            className="h-full rounded-sm min-w-[4px] transition-opacity hover:opacity-80"
+            style={{
+              width: `${acct.allocationPct}%`,
+              backgroundColor: getBrokerColor(acct.broker_type),
+            }}
+            title={`${acct.name}: ${formatCurrency(acct.value, currency, { decimals: 0 })} (${acct.allocationPct.toFixed(1)}%)`}
+          />
+        ))}
+      </div>
+
+      {/* Badges */}
+      <div className="flex flex-wrap gap-2 mt-2.5">
+        {accounts.map((acct) => (
+          <div
+            key={acct.id}
+            className="flex items-center gap-1.5 px-2.5 py-1 rounded-md text-xs font-medium text-[var(--text-secondary)] bg-[var(--bg-tertiary)]"
+          >
+            <div
+              className="w-2 h-2 rounded-full shrink-0"
+              style={{ backgroundColor: getBrokerColor(acct.broker_type) }}
+            />
+            {acct.name}
+            <span className="font-mono tabular-nums text-[11px] text-[var(--text-tertiary)]">
+              {acct.allocationPct.toFixed(1)}%
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/accounts/constants.js
+++ b/frontend/src/components/accounts/constants.js
@@ -1,0 +1,13 @@
+/**
+ * Human-readable labels for account types displayed in cards and sidebar.
+ */
+export const TYPE_LABELS = {
+  Brokerage: 'Brokerage',
+  Pension: 'Pension',
+  StudyFund: 'Study Fund',
+  Bank: 'Bank',
+  CryptoExchange: 'Crypto',
+  CryptoWallet: 'Crypto',
+  SelfCustodied: 'Self-Custody',
+  FamilyOffice: 'Family Office',
+};

--- a/frontend/src/components/accounts/icons.jsx
+++ b/frontend/src/components/accounts/icons.jsx
@@ -21,3 +21,35 @@ export function XMarkIcon({ className }) {
     </svg>
   );
 }
+
+export function PencilSquareIcon({ className }) {
+  return (
+    <svg className={className} fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
+      <path strokeLinecap="round" strokeLinejoin="round" d="M16.862 4.487l1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L10.582 16.07a4.5 4.5 0 0 1-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 0 1 1.13-1.897l8.932-8.931Zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0 1 15.75 21H5.25A2.25 2.25 0 0 1 3 18.75V8.25A2.25 2.25 0 0 1 5.25 6H10" />
+    </svg>
+  );
+}
+
+export function TrashIcon({ className }) {
+  return (
+    <svg className={className} fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
+      <path strokeLinecap="round" strokeLinejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" />
+    </svg>
+  );
+}
+
+export function CloudArrowUpIcon({ className }) {
+  return (
+    <svg className={className} fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
+      <path strokeLinecap="round" strokeLinejoin="round" d="M12 16.5V9.75m0 0 3 3m-3-3-3 3M6.75 19.5a4.5 4.5 0 0 1-1.41-8.775 5.25 5.25 0 0 1 10.233-2.33 3 3 0 0 1 3.758 3.848A3.752 3.752 0 0 1 18 19.5H6.75Z" />
+    </svg>
+  );
+}
+
+export function KeyIcon({ className }) {
+  return (
+    <svg className={className} fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
+      <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 5.25a3 3 0 0 1 3 3m3 0a6 6 0 0 1-7.029 5.912c-.563-.097-1.159.026-1.563.43L10.5 17.25H8.25v2.25H6v2.25H2.25v-2.818c0-.597.237-1.17.659-1.591l6.499-6.499c.404-.404.527-1 .43-1.563A6 6 0 0 1 21.75 8.25Z" />
+    </svg>
+  );
+}

--- a/frontend/src/components/accounts/icons.jsx
+++ b/frontend/src/components/accounts/icons.jsx
@@ -1,0 +1,23 @@
+export function PlusIcon({ className }) {
+  return (
+    <svg className={className} fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
+      <path strokeLinecap="round" strokeLinejoin="round" d="M12 5v14m-7-7h14" />
+    </svg>
+  );
+}
+
+export function ExternalLinkIcon({ className }) {
+  return (
+    <svg className={className} fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
+      <path strokeLinecap="round" strokeLinejoin="round" d="m4.5 19.5 15-15m0 0H8.25m11.25 0v11.25" />
+    </svg>
+  );
+}
+
+export function XMarkIcon({ className }) {
+  return (
+    <svg className={className} fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
+      <path strokeLinecap="round" strokeLinejoin="round" d="M18 6 6 18M6 6l12 12" />
+    </svg>
+  );
+}

--- a/frontend/src/components/accounts/index.js
+++ b/frontend/src/components/accounts/index.js
@@ -1,0 +1,4 @@
+export { AllocationStrip } from './AllocationStrip';
+export { AccountCard } from './AccountCard';
+export { AccountGrid } from './AccountGrid';
+export { AccountSidebar } from './AccountSidebar';

--- a/frontend/src/hooks/useAccountsData.js
+++ b/frontend/src/hooks/useAccountsData.js
@@ -17,7 +17,7 @@ function buildQuery(params) {
 }
 
 function getSyncStatus(lastSync) {
-  if (!lastSync) return { status: 'unknown', color: 'text-[var(--text-faint)]' };
+  if (!lastSync) return { status: 'unknown', color: 'bg-[var(--text-faint)]' };
   const diffDays = Math.floor((Date.now() - new Date(lastSync)) / 86400000);
   if (diffDays <= 7) return { status: 'green', color: 'bg-[var(--positive)]' };
   if (diffDays <= 30) return { status: 'amber', color: 'bg-[var(--warning)]' };
@@ -74,6 +74,7 @@ export function useAccountsData() {
   const [rawAccounts, setRawAccounts] = useState([]);
   const [dashboardAccounts, setDashboardAccounts] = useState([]);
   const [positions, setPositions] = useState([]);
+  const [positionsTruncated, setPositionsTruncated] = useState(false);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [refreshKey, setRefreshKey] = useState(0);
@@ -92,7 +93,7 @@ export function useAccountsData() {
 
       try {
         const [accountsData, dashboardData, positionsData] = await Promise.all([
-          fetchJson(`/accounts${buildQuery({ is_active: true, ...shared })}`, 'accounts'),
+          fetchJson(`/accounts${buildQuery({ is_active: true, limit: 100, ...shared })}`, 'accounts'),
           fetchJson(`/dashboard/summary${buildQuery(withCurrency)}`, 'dashboard'),
           fetchJson(`/positions${buildQuery({ ...withCurrency, limit: 100 })}`, 'positions'),
         ]);
@@ -102,6 +103,7 @@ export function useAccountsData() {
         setRawAccounts(accountsData.items);
         setDashboardAccounts(dashboardData.accounts || []);
         setPositions(positionsData.items || []);
+        setPositionsTruncated(positionsData.has_more || false);
       } catch (err) {
         if (!cancelled) setError(err.message);
       } finally {
@@ -142,5 +144,5 @@ export function useAccountsData() {
     return { accounts: enriched, accountHoldings: holdingsMap, totalValue: total };
   }, [rawAccounts, dashboardAccounts, positions]);
 
-  return { accounts, accountHoldings, totalValue, loading, error, currency, refresh };
+  return { accounts, accountHoldings, totalValue, loading, error, currency, refresh, positionsTruncated };
 }

--- a/frontend/src/hooks/useAccountsData.js
+++ b/frontend/src/hooks/useAccountsData.js
@@ -1,0 +1,146 @@
+import { useState, useEffect, useMemo } from 'react';
+import { useCurrency, usePortfolio } from '../contexts';
+import { api } from '../lib';
+
+async function fetchJson(endpoint, label) {
+  const res = await api(endpoint);
+  if (!res.ok) throw new Error(`Failed to fetch ${label}: ${res.statusText}`);
+  return res.json();
+}
+
+function buildQuery(params) {
+  const search = new URLSearchParams();
+  for (const [key, value] of Object.entries(params)) {
+    if (value != null) search.set(key, value);
+  }
+  return `?${search.toString()}`;
+}
+
+function getSyncStatus(lastSync) {
+  if (!lastSync) return { status: 'unknown', color: 'text-[var(--text-faint)]' };
+  const diffDays = Math.floor((Date.now() - new Date(lastSync)) / 86400000);
+  if (diffDays <= 7) return { status: 'green', color: 'bg-[var(--positive)]' };
+  if (diffDays <= 30) return { status: 'amber', color: 'bg-[var(--warning)]' };
+  return { status: 'red', color: 'bg-[var(--negative)]' };
+}
+
+function formatLastSync(dateStr) {
+  if (!dateStr) return 'Never';
+  const diffMs = Date.now() - new Date(dateStr);
+  const diffMins = Math.floor(diffMs / 60000);
+  if (diffMins < 1) return 'Just now';
+  if (diffMins < 60) return `${diffMins} min ago`;
+  const diffHours = Math.floor(diffMs / 3600000);
+  if (diffHours < 24) return `${diffHours}h ago`;
+  const diffDays = Math.floor(diffMs / 86400000);
+  if (diffDays === 1) return 'Yesterday';
+  if (diffDays < 30) return `${diffDays} days ago`;
+  return new Date(dateStr).toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+}
+
+/**
+ * Groups the positions endpoint's per-account breakdown by account_id.
+ * Returns Map<accountId, Array<{ symbol, name, assetClass, quantity, marketValue, pnl, pnlPct }>>
+ */
+function groupHoldingsByAccount(positions) {
+  const map = new Map();
+  for (const pos of positions) {
+    for (const acct of pos.accounts || []) {
+      if (!map.has(acct.account_id)) map.set(acct.account_id, []);
+      map.get(acct.account_id).push({
+        symbol: pos.symbol,
+        name: pos.name,
+        assetClass: pos.asset_class,
+        quantity: acct.quantity,
+        costBasis: acct.cost_basis,
+        marketValue: acct.market_value,
+        pnl: acct.pnl,
+        pnlPct: acct.pnl_pct,
+      });
+    }
+  }
+  // Sort each account's holdings by market value descending
+  for (const holdings of map.values()) {
+    holdings.sort((a, b) => (b.marketValue || 0) - (a.marketValue || 0));
+  }
+  return map;
+}
+
+export function useAccountsData() {
+  const { currency: globalCurrency } = useCurrency();
+  const { selectedPortfolioId, portfolioCurrency } = usePortfolio();
+  const currency = portfolioCurrency || globalCurrency;
+
+  const [rawAccounts, setRawAccounts] = useState([]);
+  const [dashboardAccounts, setDashboardAccounts] = useState([]);
+  const [positions, setPositions] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [refreshKey, setRefreshKey] = useState(0);
+
+  const refresh = () => setRefreshKey((k) => k + 1);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function fetchAll() {
+      setLoading(true);
+      setError(null);
+
+      const shared = { portfolio_id: selectedPortfolioId };
+      const withCurrency = { ...shared, display_currency: currency };
+
+      try {
+        const [accountsData, dashboardData, positionsData] = await Promise.all([
+          fetchJson(`/accounts${buildQuery({ is_active: true, ...shared })}`, 'accounts'),
+          fetchJson(`/dashboard/summary${buildQuery(withCurrency)}`, 'dashboard'),
+          fetchJson(`/positions${buildQuery({ ...withCurrency, limit: 100 })}`, 'positions'),
+        ]);
+
+        if (cancelled) return;
+
+        setRawAccounts(accountsData.items);
+        setDashboardAccounts(dashboardData.accounts || []);
+        setPositions(positionsData.items || []);
+      } catch (err) {
+        if (!cancelled) setError(err.message);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+
+    fetchAll();
+    return () => { cancelled = true; };
+  }, [currency, selectedPortfolioId, refreshKey]);
+
+  // Enrich accounts with values and holdings
+  const { accounts, accountHoldings, totalValue } = useMemo(() => {
+    const valueMap = new Map();
+    for (const da of dashboardAccounts) {
+      valueMap.set(da.id, { value: da.value || 0, holdingCount: da.holding_count || 0 });
+    }
+
+    const holdingsMap = groupHoldingsByAccount(positions);
+    const total = dashboardAccounts.reduce((sum, a) => sum + (a.value || 0), 0);
+
+    const enriched = rawAccounts
+      .map((acct) => {
+        const vals = valueMap.get(acct.id) || { value: 0, holdingCount: 0 };
+        const lastSync = acct.updated_at || acct.created_at;
+        return {
+          ...acct,
+          value: vals.value,
+          holdingCount: vals.holdingCount,
+          allocationPct: total > 0 ? (vals.value / total) * 100 : 0,
+          lastSync,
+          lastSyncFormatted: formatLastSync(lastSync),
+          syncStatus: getSyncStatus(lastSync),
+        };
+      })
+      .sort((a, b) => b.value - a.value);
+
+    return { accounts: enriched, accountHoldings: holdingsMap, totalValue: total };
+  }, [rawAccounts, dashboardAccounts, positions]);
+
+  return { accounts, accountHoldings, totalValue, loading, error, currency, refresh };
+}

--- a/frontend/src/pages/AccountDetail.jsx
+++ b/frontend/src/pages/AccountDetail.jsx
@@ -1438,12 +1438,13 @@ export default function AccountDetail() {
 
     if (tabParam === 'settings') {
       setActiveTab('settings');
-      // Clear the query params after reading
       setSearchParams({}, { replace: true });
-      // Schedule scroll to API credentials
       if (scrollTo === 'api' || !scrollTo) {
         setShouldScrollToCredentials(true);
       }
+    } else if (tabParam === 'holdings' || tabParam === 'transactions') {
+      setActiveTab(tabParam);
+      setSearchParams({}, { replace: true });
     }
   }, [searchParams, setSearchParams]);
 

--- a/frontend/src/pages/Accounts.jsx
+++ b/frontend/src/pages/Accounts.jsx
@@ -215,22 +215,25 @@ export default function Accounts() {
         existingAccountNames={accounts.map((a) => a.name)}
       />
 
-      {/* Batch upload modal — onComplete fires only on successful import */}
-      <BatchUploadModal
-        isOpen={showBatchUpload}
-        onClose={() => {
-          setShowBatchUpload(false);
-          setActiveModalAccount(null);
-        }}
-        onComplete={() => {
-          setShowBatchUpload(false);
-          setActiveModalAccount(null);
-          refresh();
-        }}
-        accountId={activeModalAccount?.id}
-        brokerType={activeModalAccount?.broker_type}
-        supportedFormats={getBrokerConfig(activeModalAccount?.broker_type)?.supportedFormats || []}
-      />
+      {/* Batch upload modal — conditionally rendered so sessionId resets on each open.
+          onComplete fires only on successful import. */}
+      {showBatchUpload && (
+        <BatchUploadModal
+          isOpen={showBatchUpload}
+          onClose={() => {
+            setShowBatchUpload(false);
+            setActiveModalAccount(null);
+          }}
+          onComplete={() => {
+            setShowBatchUpload(false);
+            setActiveModalAccount(null);
+            refresh();
+          }}
+          accountId={activeModalAccount?.id}
+          brokerType={activeModalAccount?.broker_type}
+          supportedFormats={getBrokerConfig(activeModalAccount?.broker_type)?.supportedFormats || []}
+        />
+      )}
 
       {/* API credentials modal */}
       <ApiCredentialsModal

--- a/frontend/src/pages/Accounts.jsx
+++ b/frontend/src/pages/Accounts.jsx
@@ -7,7 +7,7 @@
  * - GET /api/positions
  */
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { api } from '../lib';
 import { usePortfolio } from '../contexts';
 import { useAccountsData } from '../hooks/useAccountsData';
@@ -32,6 +32,15 @@ export default function Accounts() {
   const liveSelectedAccount = selectedAccount
     ? accounts.find((a) => a.id === selectedAccount.id) ?? null
     : null;
+
+  // Preserve the last non-null holdings so they stay visible during the
+  // 200ms sidebar slide-out animation after liveSelectedAccount becomes null.
+  const prevHoldingsRef = useRef([]);
+  const liveHoldings = liveSelectedAccount
+    ? accountHoldings.get(liveSelectedAccount.id) || []
+    : null;
+  if (liveHoldings !== null) prevHoldingsRef.current = liveHoldings;
+  const renderHoldings = liveHoldings ?? prevHoldingsRef.current;
 
   // Fetch linkable accounts when wizard opens
   useEffect(() => {
@@ -163,7 +172,7 @@ export default function Accounts() {
       {/* Account detail sidebar */}
       <AccountSidebar
         account={liveSelectedAccount}
-        holdings={liveSelectedAccount ? accountHoldings.get(liveSelectedAccount.id) || [] : []}
+        holdings={renderHoldings}
         currency={currency}
         onClose={handleCloseSidebar}
         onRename={handleRename}

--- a/frontend/src/pages/Accounts.jsx
+++ b/frontend/src/pages/Accounts.jsx
@@ -1,607 +1,33 @@
 /**
- * Accounts Page - Finch Redesign
+ * Accounts Page - Grid card layout with allocation strip and detail sidebar.
  *
- * Purpose: Account management with integrated import flow
- *
- * Wired to real API endpoints:
+ * API endpoints (via useAccountsData hook):
  * - GET /api/accounts
- * - GET /api/dashboard/summary (for account values)
+ * - GET /api/dashboard/summary
+ * - GET /api/positions
+ * - GET /api/broker-data/supported-brokers
  */
 
-import { useState, useEffect, useRef } from 'react';
-import { useNavigate } from 'react-router-dom';
-import { cn, formatCurrency, api } from '../lib';
-import { useCurrency, usePortfolio } from '../contexts';
+import { useState, useEffect } from 'react';
+import { api } from '../lib';
+import { usePortfolio } from '../contexts';
+import { useAccountsData } from '../hooks/useAccountsData';
 import { PageContainer } from '../components/layout';
 import { Skeleton } from '../components/ui';
-import { ApiCredentialsModal } from '../components/ApiCredentialsModal';
+import { AllocationStrip, AccountGrid, AccountSidebar } from '../components/accounts';
 import { AccountWizard } from '../components/AccountWizard';
-import { BatchUploadModal } from '../components/BatchUploadModal';
-import { BrokerLogo } from '../components/AccountWizard/BrokerLogo';
-import { CoverageTimeline } from '../components/CoverageTimeline';
-
-// ============================================
-// ICONS
-// ============================================
-
-function PlusIcon({ className }) {
-  return (
-    <svg className={className} fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
-      <path strokeLinecap="round" strokeLinejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
-    </svg>
-  );
-}
-
-function ChevronDownIcon({ className }) {
-  return (
-    <svg className={className} fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
-      <path strokeLinecap="round" strokeLinejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5" />
-    </svg>
-  );
-}
-
-function XMarkIcon({ className }) {
-  return (
-    <svg className={className} fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
-      <path strokeLinecap="round" strokeLinejoin="round" d="M6 18 18 6M6 6l12 12" />
-    </svg>
-  );
-}
-
-function LinkIcon({ className }) {
-  return (
-    <svg className={className} fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
-      <path strokeLinecap="round" strokeLinejoin="round" d="M13.19 8.688a4.5 4.5 0 0 1 1.242 7.244l-4.5 4.5a4.5 4.5 0 0 1-6.364-6.364l1.757-1.757m13.35-.622 1.757-1.757a4.5 4.5 0 0 0-6.364-6.364l-4.5 4.5a4.5 4.5 0 0 0 1.242 7.244" />
-    </svg>
-  );
-}
-
-function DocumentArrowUpIcon({ className }) {
-  return (
-    <svg className={className} fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
-      <path strokeLinecap="round" strokeLinejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m6.75 12-3-3m0 0-3 3m3-3v6m-1.5-15H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z" />
-    </svg>
-  );
-}
-
-function TrashIcon({ className }) {
-  return (
-    <svg className={className} fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
-      <path strokeLinecap="round" strokeLinejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" />
-    </svg>
-  );
-}
-
-function ExclamationTriangleIcon({ className }) {
-  return (
-    <svg className={className} fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
-      <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126ZM12 15.75h.007v.008H12v-.008Z" />
-    </svg>
-  );
-}
-
-function PencilIcon({ className }) {
-  return (
-    <svg className={className} fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
-      <path strokeLinecap="round" strokeLinejoin="round" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L6.832 19.82a4.5 4.5 0 0 1-1.897 1.13l-2.685.8.8-2.685a4.5 4.5 0 0 1 1.13-1.897L16.863 4.487Zm0 0L19.5 7.125" />
-    </svg>
-  );
-}
-
-function ArrowRightIcon({ className }) {
-  return (
-    <svg className={className} fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
-      <path strokeLinecap="round" strokeLinejoin="round" d="M13.5 4.5 21 12m0 0-7.5 7.5M21 12H3" />
-    </svg>
-  );
-}
-
-function BuildingLibraryIcon({ className }) {
-  return (
-    <svg className={className} fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
-      <path strokeLinecap="round" strokeLinejoin="round" d="M12 21v-8.25M15.75 21v-8.25M8.25 21v-8.25M3 9l9-6 9 6m-1.5 12V10.332A48.36 48.36 0 0 0 12 9.75c-2.551 0-5.056.2-7.5.582V21M3 21h18M12 6.75h.008v.008H12V6.75Z" />
-    </svg>
-  );
-}
-
-function ChartBarIcon({ className }) {
-  return (
-    <svg className={className} fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
-      <path strokeLinecap="round" strokeLinejoin="round" d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 0 1 3 19.875v-6.75ZM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V8.625ZM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V4.125Z" />
-    </svg>
-  );
-}
-
-function CheckIcon({ className }) {
-  return (
-    <svg className={className} fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
-      <path strokeLinecap="round" strokeLinejoin="round" d="m4.5 12.75 6 6 9-13.5" />
-    </svg>
-  );
-}
-
-// ============================================
-// UTILITY FUNCTIONS
-// ============================================
-
-const formatLastSync = (dateStr) => {
-  const date = new Date(dateStr);
-  const now = new Date();
-  const diffMs = now - date;
-  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
-
-  if (diffDays === 0) {
-    const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
-    if (diffHours === 0) {
-      const diffMins = Math.floor(diffMs / (1000 * 60));
-      return `${diffMins} minutes ago`;
-    }
-    return `${diffHours} hours ago`;
-  } else if (diffDays === 1) {
-    return 'Yesterday';
-  } else if (diffDays < 30) {
-    return `${diffDays} days ago`;
-  } else {
-    return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
-  }
-};
-
-const getStatusInfo = (lastSync) => {
-  const date = new Date(lastSync);
-  const now = new Date();
-  const diffDays = Math.floor((now - date) / (1000 * 60 * 60 * 24));
-
-  if (diffDays <= 7) {
-    return { status: 'connected', label: 'Connected', color: 'text-emerald-600 dark:text-emerald-400' };
-  } else if (diffDays <= 30) {
-    return { status: 'stale', label: 'Needs sync', color: 'text-amber-600 dark:text-amber-400' };
-  } else {
-    return { status: 'outdated', label: 'Outdated', color: 'text-red-600 dark:text-red-400' };
-  }
-};
-
-// ============================================
-// ALERT DIALOG COMPONENT
-// ============================================
-
-function AlertDialog({ isOpen, onClose, onConfirm, title, description, confirmLabel = 'Delete', variant = 'danger' }) {
-  if (!isOpen) return null;
-
-  return (
-    <>
-      {/* Backdrop */}
-      <div className="fixed inset-0 bg-black/50 z-50" onClick={onClose} />
-
-      {/* Dialog */}
-      <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
-        <div className="bg-[var(--bg-primary)] rounded-xl shadow-xl max-w-md w-full p-6">
-          <div className="flex items-start gap-4">
-            <div className={cn(
-              'p-2 rounded-full',
-              variant === 'danger' ? 'bg-red-100 dark:bg-red-950/40' : 'bg-amber-100 dark:bg-amber-950/40'
-            )}>
-              <ExclamationTriangleIcon className={cn(
-                'w-6 h-6',
-                variant === 'danger' ? 'text-red-600 dark:text-red-400' : 'text-amber-600 dark:text-amber-400'
-              )} />
-            </div>
-            <div className="flex-1">
-              <h3 className="text-lg font-semibold text-[var(--text-primary)]">{title}</h3>
-              <p className="text-sm text-[var(--text-secondary)] mt-1">{description}</p>
-            </div>
-          </div>
-
-          <div className="flex justify-end gap-3 mt-6">
-            <button
-              onClick={onClose}
-              className="px-4 py-2 rounded-lg text-sm font-medium bg-[var(--bg-tertiary)] text-[var(--text-primary)] hover:bg-[var(--border-primary)] transition-colors cursor-pointer"
-            >
-              Cancel
-            </button>
-            <button
-              onClick={onConfirm}
-              className={cn(
-                'px-4 py-2 rounded-lg text-sm font-medium text-white transition-colors cursor-pointer',
-                variant === 'danger'
-                  ? 'bg-red-600 hover:bg-red-700'
-                  : 'bg-amber-600 hover:bg-amber-700'
-              )}
-            >
-              {confirmLabel}
-            </button>
-          </div>
-        </div>
-      </div>
-    </>
-  );
-}
-
-// ============================================
-// DATA COVERAGE BAR
-// ============================================
-
-function DataCoverageBar({ coverage }) {
-  if (!coverage || !coverage.start_date || !coverage.end_date) {
-    return (
-      <div className="text-sm text-[var(--text-tertiary)]">
-        No data coverage information available
-      </div>
-    );
-  }
-
-  const files = [
-    {
-      fileName: 'All sources',
-      startDate: coverage.start_date,
-      endDate: coverage.end_date,
-      transactions: coverage.transactions || 0,
-    },
-  ];
-
-  return (
-    <div>
-      <CoverageTimeline files={files} gaps={coverage.gaps || []} />
-      <div className="flex items-center gap-4 mt-2 text-xs text-[var(--text-secondary)]">
-        {coverage.sources > 0 && (
-          <span>{coverage.sources} source{coverage.sources > 1 ? 's' : ''}</span>
-        )}
-      </div>
-    </div>
-  );
-}
-
-// ============================================
-// ACCOUNT CARD COMPONENT
-// ============================================
-
-function AccountCard({ account, currency, brokerConfig, onDelete, onRename, onRefresh }) {
-  const [isExpanded, setIsExpanded] = useState(false);
-  const [isEditing, setIsEditing] = useState(false);
-  const [editName, setEditName] = useState(account.name);
-  const [showApiModal, setShowApiModal] = useState(false);
-  const [hasApiCredentials, setHasApiCredentials] = useState(false);
-  const [showBatchUpload, setShowBatchUpload] = useState(false);
-  const navigate = useNavigate();
-  const { selectedPortfolioId } = usePortfolio();
-  const statusInfo = getStatusInfo(account.last_sync);
-  const inputRef = useRef(null);
-
-  // Determine if this is a shared account (in multiple portfolios)
-  const isSharedAccount = account.portfolio_ids && account.portfolio_ids.length > 1;
-  const willUnlink = selectedPortfolioId && isSharedAccount;
-
-  // Get broker config (API support and file formats)
-  const supportsApi = brokerConfig?.has_api ?? false;
-  const supportedFormats = brokerConfig?.supported_formats || [];
-  const formatDisplay = supportedFormats.map(f => f.replace('.', '').toUpperCase()).join(', ') || 'Files';
-
-  // Check if API credentials exist
-  useEffect(() => {
-    if (supportsApi && account.id) {
-      api(`/brokers/${account.broker_type}/credentials/${account.id}`)
-        .then((res) => {
-          if (res.ok) {
-            return res.json();
-          }
-          return null;
-        })
-        .then((data) => {
-          setHasApiCredentials(data?.has_credentials ?? false);
-        })
-        .catch(() => setHasApiCredentials(false));
-    }
-  }, [supportsApi, account.id, account.broker_type]);
-
-  const handleEditClick = (e) => {
-    e.stopPropagation();
-    setEditName(account.name);
-    setIsEditing(true);
-    // Focus input after render
-    setTimeout(() => inputRef.current?.focus(), 0);
-  };
-
-  const handleSaveEdit = (e) => {
-    e.stopPropagation();
-    if (editName.trim() && editName.trim() !== account.name) {
-      onRename(account.id, editName.trim());
-    }
-    setIsEditing(false);
-  };
-
-  const handleCancelEdit = (e) => {
-    e.stopPropagation();
-    setEditName(account.name);
-    setIsEditing(false);
-  };
-
-  const handleKeyDown = (e) => {
-    if (e.key === 'Enter') {
-      handleSaveEdit(e);
-    } else if (e.key === 'Escape') {
-      handleCancelEdit(e);
-    }
-  };
-
-  const handleViewDetails = (e) => {
-    e.stopPropagation();
-    navigate(`/accounts/${account.id}`);
-  };
-
-  const handleUploadFile = (e) => {
-    e.stopPropagation();
-    setShowBatchUpload(true);
-  };
-
-  const handleConnectApi = (e) => {
-    e.stopPropagation();
-    setShowApiModal(true);
-  };
-
-  return (
-    <div className="bg-[var(--bg-secondary)] rounded-xl border border-[var(--border-primary)] overflow-hidden shadow-sm dark:shadow-none">
-      {/* Card Header - Always visible */}
-      <div
-        onClick={() => !isEditing && setIsExpanded(!isExpanded)}
-        className="flex items-center justify-between p-5 cursor-pointer hover:bg-[var(--bg-tertiary)] transition-colors"
-      >
-        <div className="flex items-center gap-4">
-          {account.broker_type ? (
-            <BrokerLogo type={account.broker_type} className="size-12 rounded-lg" />
-          ) : (
-            <div className="p-3 rounded-xl bg-accent/10">
-              <ChartBarIcon className="w-6 h-6 text-accent" />
-            </div>
-          )}
-          <div>
-            <div className="flex items-center gap-2">
-              {isEditing ? (
-                <div className="flex items-center gap-1" onClick={(e) => e.stopPropagation()}>
-                  <input
-                    ref={inputRef}
-                    type="text"
-                    value={editName}
-                    onChange={(e) => setEditName(e.target.value)}
-                    onKeyDown={handleKeyDown}
-                    onBlur={handleSaveEdit}
-                    className={cn(
-                      'px-2 py-0.5 rounded text-sm font-semibold',
-                      'bg-[var(--bg-primary)] border border-accent',
-                      'text-[var(--text-primary)]',
-                      'focus:outline-none focus:ring-2 focus:ring-accent/50'
-                    )}
-                  />
-                  <button
-                    onClick={handleSaveEdit}
-                    className="p-1 rounded hover:bg-emerald-100 dark:hover:bg-emerald-950/40 transition-colors cursor-pointer"
-                    title="Save"
-                  >
-                    <CheckIcon className="w-4 h-4 text-emerald-600 dark:text-emerald-400" />
-                  </button>
-                  <button
-                    onClick={handleCancelEdit}
-                    className="p-1 rounded hover:bg-red-100 dark:hover:bg-red-950/40 transition-colors cursor-pointer"
-                    title="Cancel"
-                  >
-                    <XMarkIcon className="w-4 h-4 text-red-600 dark:text-red-400" />
-                  </button>
-                </div>
-              ) : (
-                <>
-                  <h3 className="font-semibold text-[var(--text-primary)]">{account.name}</h3>
-                  <button
-                    onClick={handleEditClick}
-                    className="p-1 rounded hover:bg-[var(--bg-primary)] transition-colors cursor-pointer"
-                    title="Rename account"
-                  >
-                    <PencilIcon className="w-3.5 h-3.5 text-[var(--text-tertiary)] hover:text-[var(--text-secondary)]" />
-                  </button>
-                </>
-              )}
-            </div>
-            <p className="text-sm text-[var(--text-secondary)]">
-              {account.institution} · {account.account_type}
-            </p>
-            <div className="flex items-center gap-2 mt-1">
-              <span className={cn('w-2 h-2 rounded-full', {
-                'bg-emerald-500': statusInfo.status === 'connected',
-                'bg-amber-500': statusInfo.status === 'stale',
-                'bg-red-500': statusInfo.status === 'outdated',
-              })} />
-              <span className={cn('text-xs', statusInfo.color)}>
-                {statusInfo.label}
-              </span>
-              <span className="text-xs text-[var(--text-tertiary)]">
-                · Last sync: {formatLastSync(account.last_sync)}
-              </span>
-            </div>
-          </div>
-        </div>
-
-        <div className="flex items-center gap-4">
-          <p className="text-xl font-semibold font-mono tabular-nums text-[var(--text-primary)]">
-            {formatCurrency(account.value, currency)}
-          </p>
-          <ChevronDownIcon className={cn(
-            'w-5 h-5 text-[var(--text-tertiary)] transition-transform',
-            isExpanded && 'rotate-180'
-          )} />
-        </div>
-      </div>
-
-      {/* Expanded Content */}
-      {isExpanded && (
-        <div className="border-t border-[var(--border-primary)]">
-          {/* View Details Link */}
-          <button
-            onClick={handleViewDetails}
-            className="w-full flex items-center justify-between p-4 border-b border-[var(--border-primary)] hover:bg-[var(--bg-tertiary)] transition-colors cursor-pointer group"
-          >
-            <span className="text-sm font-medium text-accent group-hover:text-accent/80">
-              View Account Details
-            </span>
-            <ArrowRightIcon className="w-4 h-4 text-accent group-hover:text-accent/80" />
-          </button>
-
-          {/* Data Coverage Section */}
-          <div className="p-5 border-b border-[var(--border-primary)]">
-            <h4 className="text-sm font-medium text-[var(--text-primary)] mb-3">Data Coverage</h4>
-            <DataCoverageBar coverage={account.coverage} />
-          </div>
-
-          {/* Import Options Section */}
-          <div className="p-5 border-b border-[var(--border-primary)]">
-            <h4 className="text-sm font-medium text-[var(--text-primary)] mb-3">Import Data</h4>
-            <div className={cn('grid gap-3', supportsApi ? 'grid-cols-2' : 'grid-cols-1')}>
-              {supportsApi && (
-                <button
-                  onClick={handleConnectApi}
-                  className={cn(
-                    'flex items-center justify-center gap-2 p-4 rounded-lg border-2',
-                    hasApiCredentials
-                      ? 'border-emerald-300 dark:border-emerald-700 bg-emerald-50 dark:bg-emerald-950/30'
-                      : 'border-dashed border-[var(--border-secondary)] hover:border-accent hover:bg-accent/5',
-                    'transition-colors cursor-pointer group'
-                  )}
-                >
-                  {hasApiCredentials ? (
-                    <CheckIcon className="w-5 h-5 text-emerald-600 dark:text-emerald-400" />
-                  ) : (
-                    <LinkIcon className="w-5 h-5 text-[var(--text-tertiary)] group-hover:text-accent" />
-                  )}
-                  <div className="text-left">
-                    <p className={cn(
-                      'text-sm font-medium',
-                      hasApiCredentials
-                        ? 'text-emerald-600 dark:text-emerald-400'
-                        : 'text-[var(--text-primary)] group-hover:text-accent'
-                    )}>
-                      {hasApiCredentials ? 'API Connected' : 'Connect API'}
-                    </p>
-                    <p className="text-xs text-[var(--text-tertiary)]">
-                      {hasApiCredentials ? 'Click to update' : 'Automatic sync'}
-                    </p>
-                  </div>
-                </button>
-              )}
-
-              <button
-                onClick={handleUploadFile}
-                className="flex items-center justify-center gap-2 p-4 rounded-lg border-2 border-dashed border-[var(--border-secondary)] hover:border-accent hover:bg-accent/5 transition-colors cursor-pointer group"
-              >
-                <DocumentArrowUpIcon className="w-5 h-5 text-[var(--text-tertiary)] group-hover:text-accent" />
-                <div className="text-left">
-                  <p className="text-sm font-medium text-[var(--text-primary)] group-hover:text-accent">Upload File</p>
-                  <p className="text-xs text-[var(--text-tertiary)]">{formatDisplay || 'Supported formats'}</p>
-                </div>
-              </button>
-            </div>
-          </div>
-
-          {/* Danger Zone */}
-          <div className={cn(
-            'p-5',
-            willUnlink
-              ? 'bg-amber-50/50 dark:bg-amber-950/20'
-              : 'bg-red-50/50 dark:bg-red-950/20'
-          )}>
-            {!willUnlink && (
-              <h4 className="text-sm font-medium mb-3 text-red-600 dark:text-red-400">
-                Danger Zone
-              </h4>
-            )}
-            <button
-              onClick={(e) => {
-                e.stopPropagation();
-                onDelete(account);
-              }}
-              className={cn(
-                'flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium',
-                'transition-colors cursor-pointer',
-                willUnlink
-                  ? 'border border-amber-300 dark:border-amber-800 text-amber-600 dark:text-amber-400 hover:bg-amber-100 dark:hover:bg-amber-950/40'
-                  : 'border border-red-300 dark:border-red-800 text-red-600 dark:text-red-400 hover:bg-red-100 dark:hover:bg-red-950/40'
-              )}
-            >
-              <TrashIcon className="w-4 h-4" />
-              {willUnlink ? 'Unlink from Portfolio' : 'Delete Account'}
-            </button>
-            <p className="text-xs text-[var(--text-tertiary)] mt-2">
-              {willUnlink
-                ? 'This account is in multiple portfolios. Unlinking will only remove it from this portfolio.'
-                : 'This will permanently delete this account and all associated data.'}
-            </p>
-          </div>
-        </div>
-      )}
-
-      {/* API Credentials Modal */}
-      <ApiCredentialsModal
-        isOpen={showApiModal}
-        onClose={() => setShowApiModal(false)}
-        account={account}
-        hasCredentials={hasApiCredentials}
-        onGoToSettings={() => navigate(`/accounts/${account.id}?tab=settings`)}
-        onCredentialsSaved={() => {
-          setHasApiCredentials(true);
-          onRefresh?.();
-        }}
-      />
-
-      {/* Batch Upload Modal */}
-      <BatchUploadModal
-        isOpen={showBatchUpload}
-        onClose={() => setShowBatchUpload(false)}
-        accountId={account.id}
-        brokerType={account.broker_type}
-        supportedFormats={supportedFormats}
-        onComplete={() => onRefresh?.()}
-      />
-    </div>
-  );
-}
-
-// ============================================
-// EMPTY STATE
-// ============================================
-
-function EmptyState({ onAddAccount }) {
-  return (
-    <div className="text-center py-16">
-      <div className="inline-flex p-4 rounded-full bg-[var(--bg-secondary)] mb-4">
-        <BuildingLibraryIcon className="w-12 h-12 text-[var(--text-tertiary)]" />
-      </div>
-      <h3 className="text-lg font-semibold text-[var(--text-primary)]">No accounts yet</h3>
-      <p className="text-[var(--text-secondary)] mt-1 max-w-sm mx-auto">
-        Add your first investment account to start tracking your portfolio.
-      </p>
-      <button
-        onClick={onAddAccount}
-        className="mt-6 inline-flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium bg-accent text-white hover:bg-accent/90 transition-colors cursor-pointer"
-      >
-        <PlusIcon className="w-4 h-4" />
-        Add Account
-      </button>
-    </div>
-  );
-}
-
-// ============================================
-// MAIN COMPONENT
-// ============================================
+import { PlusIcon } from '../components/accounts/icons';
 
 export default function Accounts() {
-  const { currency: globalCurrency } = useCurrency();
-  const { selectedPortfolioId, portfolioCurrency } = usePortfolio();
-  // Use portfolio's currency when viewing a specific portfolio, otherwise use global currency
-  const currency = portfolioCurrency || globalCurrency;
-  const [accounts, setAccounts] = useState([]);
-  const [brokerConfig, setBrokerConfig] = useState({}); // Maps broker_type to config
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(null);
+  const { selectedPortfolioId } = usePortfolio();
+  const {
+    accounts, accountHoldings, totalValue,
+    loading, error, currency, refresh,
+  } = useAccountsData();
+
+  const [selectedAccount, setSelectedAccount] = useState(null);
   const [showWizard, setShowWizard] = useState(false);
   const [linkableAccounts, setLinkableAccounts] = useState([]);
-  const [deleteDialog, setDeleteDialog] = useState({ isOpen: false, account: null });
-  const [refreshKey, setRefreshKey] = useState(0);
 
   // Fetch linkable accounts when wizard opens
   useEffect(() => {
@@ -613,218 +39,40 @@ export default function Accounts() {
     }
   }, [showWizard, selectedPortfolioId]);
 
-  // Fetch accounts and values
-  useEffect(() => {
-    const fetchData = async () => {
-      setLoading(true);
-      setError(null);
+  const handleCardClick = (account) => setSelectedAccount(account);
+  const handleCloseSidebar = () => setSelectedAccount(null);
+  const handleAddAccount = () => setShowWizard(true);
 
-      // Build query params - add portfolio_id if a specific portfolio is selected
-      const portfolioParam = selectedPortfolioId ? `&portfolio_id=${selectedPortfolioId}` : '';
-
-      try {
-        // Fetch accounts, dashboard summary, and broker config in parallel
-        const [accountsRes, dashboardRes, brokerRes] = await Promise.all([
-          api(`/accounts?is_active=true${portfolioParam}`),
-          api(`/dashboard/summary?display_currency=${currency}${portfolioParam}`),
-          api(`/broker-data/supported-brokers`),
-        ]);
-
-        if (!accountsRes.ok) {
-          throw new Error(`Failed to fetch accounts: ${accountsRes.statusText}`);
-        }
-        if (!dashboardRes.ok) {
-          throw new Error(`Failed to fetch dashboard: ${dashboardRes.statusText}`);
-        }
-
-        const [accountsRawData, dashboardData, brokerData] = await Promise.all([
-          accountsRes.json(),
-          dashboardRes.json(),
-          brokerRes.ok ? brokerRes.json() : [],
-        ]);
-        const accountsData = accountsRawData.items;
-
-        // Build broker config map (broker_type -> config)
-        const brokerConfigMap = {};
-        brokerData.forEach((broker) => {
-          brokerConfigMap[broker.type] = {
-            name: broker.name,
-            supported_formats: broker.supported_formats,
-            has_api: broker.has_api,
-          };
-        });
-        setBrokerConfig(brokerConfigMap);
-
-        // Create a map of account values from dashboard data
-        const accountValuesMap = {};
-        if (dashboardData.accounts) {
-          dashboardData.accounts.forEach((acc) => {
-            accountValuesMap[acc.id] = acc.value;
-          });
-        }
-
-        // Fetch coverage data for each account from the broker-data API
-        const coveragePromises = accountsData.map(async (account) => {
-          try {
-            const res = await api(`/broker-data/coverage/${account.id}`);
-            if (res.ok) {
-              const data = await res.json();
-              // The response is keyed by broker type (e.g., 'ibkr', 'meitav')
-              const brokerType = account.broker_type;
-              const brokerCoverage = data.brokers?.[brokerType];
-              if (brokerCoverage && brokerCoverage.has_data) {
-                return {
-                  id: account.id,
-                  coverage: {
-                    start_date: brokerCoverage.coverage?.start_date,
-                    end_date: brokerCoverage.coverage?.end_date,
-                    transactions: brokerCoverage.totals?.transactions || 0,
-                    sources: brokerCoverage.totals?.sources || 0,
-                    gaps: brokerCoverage.gaps || [],
-                  },
-                };
-              }
-            }
-          } catch (err) {
-            console.error(`Error fetching coverage for account ${account.id}:`, err);
-          }
-          // Default coverage if API fails
-          return {
-            id: account.id,
-            coverage: {
-              start_date: account.created_at?.split('T')[0],
-              end_date: new Date().toISOString().split('T')[0],
-              transactions: 0,
-              sources: 0,
-              gaps: [],
-            },
-          };
-        });
-
-        const coverageResults = await Promise.all(coveragePromises);
-        const coverageMap = {};
-        coverageResults.forEach((c) => {
-          coverageMap[c.id] = c.coverage;
-        });
-
-        // Merge account data with values and actual coverage data
-        const enrichedAccounts = accountsData.map((account) => ({
-          ...account,
-          value: accountValuesMap[account.id] || 0,
-          last_sync: account.updated_at || account.created_at,
-          coverage: coverageMap[account.id],
-        }));
-
-        setAccounts(enrichedAccounts);
-      } catch (err) {
-        console.error('Error fetching accounts data:', err);
-        setError(err.message);
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    fetchData();
-  }, [currency, selectedPortfolioId, refreshKey]);
-
-  const handleDeleteAccount = (account) => {
-    // Determine if this is an unlink or delete operation
-    // Unlink if: viewing a specific portfolio AND account belongs to multiple portfolios
-    const isSharedAccount = account.portfolio_ids && account.portfolio_ids.length > 1;
-    const shouldUnlink = selectedPortfolioId && isSharedAccount;
-
-    setDeleteDialog({
-      isOpen: true,
-      account,
-      isUnlink: shouldUnlink,
-    });
-  };
-
-  const confirmDelete = async () => {
-    const { account, isUnlink } = deleteDialog;
-
-    try {
-      let res;
-      if (isUnlink && selectedPortfolioId) {
-        // Unlink from current portfolio only
-        res = await api(`/portfolios/${selectedPortfolioId}/accounts/${account.id}`, {
-          method: 'DELETE',
-        });
-      } else {
-        // Delete account entirely
-        res = await api(`/accounts/${account.id}`, {
-          method: 'DELETE',
-        });
-      }
-
-      if (!res.ok) {
-        const data = await res.json();
-        throw new Error(data.message || `Failed to ${isUnlink ? 'unlink' : 'delete'} account`);
-      }
-
-      // Remove from local state
-      setAccounts((prev) => prev.filter((a) => a.id !== account.id));
-    } catch (err) {
-      console.error(`Error ${deleteDialog.isUnlink ? 'unlinking' : 'deleting'} account:`, err);
-      alert(err.message);
-    }
-    setDeleteDialog({ isOpen: false, account: null, isUnlink: false });
-  };
-
-  const confirmRename = async (accountId, newName) => {
-    try {
-      const res = await api(`/accounts/${accountId}`, {
-        method: 'PUT',
-        body: JSON.stringify({ name: newName }),
-      });
-      if (!res.ok) {
-        throw new Error('Failed to rename account');
-      }
-      // Update local state
-      setAccounts((prev) =>
-        prev.map((a) => (a.id === accountId ? { ...a, name: newName } : a))
-      );
-    } catch (err) {
-      console.error('Error renaming account:', err);
-      alert('Failed to rename account');
-    }
-  };
-
-  const totalValue = accounts.reduce((sum, acc) => sum + (acc.value || 0), 0);
-
-  // Loading state
   if (loading) {
     return (
-      <PageContainer>
-        <div className="flex items-center justify-between mb-8">
+      <PageContainer className="mx-0 max-w-none">
+        <div className="flex items-start justify-between mb-5">
           <div>
-            <h1 className="text-2xl font-semibold text-[var(--text-primary)]">Accounts</h1>
-            <Skeleton className="h-5 w-48 mt-2" />
+            <h1 className="text-[22px] font-bold tracking-[-0.3px] text-[var(--text-primary)]">Accounts</h1>
+            <Skeleton className="h-4 w-32 mt-1" />
           </div>
-          <Skeleton className="h-10 w-32" />
+          <Skeleton className="h-9 w-32 rounded-lg" />
         </div>
-        <div className="space-y-4">
-          {[1, 2, 3].map((i) => (
-            <Skeleton key={i} className="h-28 w-full rounded-xl" />
+        <AllocationStrip loading />
+        <div className="grid grid-cols-[repeat(auto-fill,minmax(340px,1fr))] gap-4">
+          {[1, 2, 3, 4].map((i) => (
+            <Skeleton key={i} className="h-[220px] w-full rounded-xl" />
           ))}
         </div>
       </PageContainer>
     );
   }
 
-  // Error state
   if (error) {
     return (
-      <PageContainer>
-        <div className="flex items-center justify-between mb-8">
-          <h1 className="text-2xl font-semibold text-[var(--text-primary)]">Accounts</h1>
-        </div>
+      <PageContainer className="mx-0 max-w-none">
+        <h1 className="text-[22px] font-bold tracking-[-0.3px] text-[var(--text-primary)] mb-5">Accounts</h1>
         <div className="text-center py-12">
-          <p className="text-negative mb-2">Error loading accounts</p>
+          <p className="text-[var(--negative)] mb-2">Error loading accounts</p>
           <p className="text-[var(--text-secondary)] text-sm">{error}</p>
           <button
             onClick={() => window.location.reload()}
-            className="mt-4 px-4 py-2 bg-accent text-white rounded-lg hover:bg-accent/90 transition-colors cursor-pointer"
+            className="mt-4 px-4 py-2 bg-[var(--accent-primary)] text-white rounded-lg hover:bg-[var(--accent-hover)] transition-colors cursor-pointer"
           >
             Retry
           </button>
@@ -834,69 +82,90 @@ export default function Accounts() {
   }
 
   return (
-    <PageContainer>
-      {/* Header */}
-      <div className="flex items-center justify-between mb-8">
+    <PageContainer className="mx-0 max-w-none">
+      {/* Title bar */}
+      <div className="flex items-start justify-between mb-5">
         <div>
-          <h1 className="text-2xl font-semibold text-[var(--text-primary)]">Accounts</h1>
-          <p className="text-[var(--text-secondary)] mt-1">
-            {accounts.length} accounts · {formatCurrency(totalValue, currency)} total
+          <h1 className="text-[22px] font-bold tracking-[-0.3px] text-[var(--text-primary)]">
+            Accounts
+          </h1>
+          <p className="text-[13px] text-[var(--text-tertiary)] mt-0.5">
+            {accounts.length} account{accounts.length !== 1 ? 's' : ''}
           </p>
         </div>
         <button
-          onClick={() => setShowWizard(true)}
-          className="inline-flex items-center gap-2 px-4 py-2.5 rounded-lg text-sm font-medium bg-accent text-white hover:bg-accent/90 transition-colors cursor-pointer"
+          onClick={handleAddAccount}
+          className="flex items-center gap-1.5 px-4 py-2 bg-[var(--accent-primary)] text-white rounded-lg text-[13px] font-semibold hover:bg-[var(--accent-hover)] transition-colors cursor-pointer whitespace-nowrap"
         >
           <PlusIcon className="w-4 h-4" />
           Add Account
         </button>
       </div>
 
-      {/* Account List */}
-      {accounts.length === 0 ? (
-        <EmptyState onAddAccount={() => setShowWizard(true)} />
-      ) : (
-        <div className="space-y-4">
-          {accounts.map((account) => (
-            <AccountCard
-              key={account.id}
-              account={account}
-              currency={currency}
-              brokerConfig={brokerConfig[account.broker_type]}
-              onDelete={handleDeleteAccount}
-              onRename={confirmRename}
-              onRefresh={() => setRefreshKey((k) => k + 1)}
-            />
-          ))}
-        </div>
+      {/* Allocation strip */}
+      {accounts.length > 0 && (
+        <AllocationStrip
+          accounts={accounts}
+          totalValue={totalValue}
+          currency={currency}
+        />
       )}
 
-      {/* Account Creation Wizard */}
+      {/* Account grid (handles empty state internally via add-account card) */}
+      {accounts.length === 0 ? (
+        <EmptyState onAddAccount={handleAddAccount} />
+      ) : (
+        <AccountGrid
+          accounts={accounts}
+          accountHoldings={accountHoldings}
+          currency={currency}
+          onCardClick={handleCardClick}
+          onAddAccount={handleAddAccount}
+        />
+      )}
+
+      {/* Account detail sidebar */}
+      <AccountSidebar
+        account={selectedAccount}
+        holdings={selectedAccount ? accountHoldings.get(selectedAccount.id) || [] : []}
+        currency={currency}
+        onClose={handleCloseSidebar}
+      />
+
+      {/* Account creation wizard */}
       <AccountWizard
         isOpen={showWizard}
         onClose={() => {
           setShowWizard(false);
-          setRefreshKey((k) => k + 1);
+          refresh();
         }}
         portfolioId={selectedPortfolioId}
         linkableAccounts={linkableAccounts}
         existingAccountNames={accounts.map((a) => a.name)}
       />
-
-      {/* Delete/Unlink Confirmation Dialog */}
-      <AlertDialog
-        isOpen={deleteDialog.isOpen}
-        onClose={() => setDeleteDialog({ isOpen: false, account: null, isUnlink: false })}
-        onConfirm={confirmDelete}
-        title={deleteDialog.isUnlink ? 'Unlink from Portfolio' : 'Delete Account'}
-        description={
-          deleteDialog.isUnlink
-            ? `Are you sure you want to unlink "${deleteDialog.account?.name}" from this portfolio? The account will remain in your other portfolios.`
-            : `Are you sure you want to delete "${deleteDialog.account?.name}"? This action cannot be undone and all associated transaction data will be permanently removed.`
-        }
-        confirmLabel={deleteDialog.isUnlink ? 'Unlink' : 'Delete Account'}
-        variant={deleteDialog.isUnlink ? 'warning' : 'danger'}
-      />
     </PageContainer>
+  );
+}
+
+function EmptyState({ onAddAccount }) {
+  return (
+    <div className="text-center py-16">
+      <div className="inline-flex p-4 rounded-full bg-[var(--bg-secondary)] mb-4">
+        <svg className="w-12 h-12 text-[var(--text-tertiary)]" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
+          <path strokeLinecap="round" strokeLinejoin="round" d="M12 21v-8.25M15.75 21v-8.25M8.25 21v-8.25M3 9l9-6 9 6m-1.5 12V10.332A48.36 48.36 0 0 0 12 9.75c-2.551 0-5.056.2-7.5.582V21M3 21h18M12 6.75h.008v.008H12V6.75Z" />
+        </svg>
+      </div>
+      <h3 className="text-lg font-semibold text-[var(--text-primary)]">No accounts yet</h3>
+      <p className="text-[var(--text-secondary)] mt-1 max-w-sm mx-auto">
+        Add your first investment account to start tracking your portfolio.
+      </p>
+      <button
+        onClick={onAddAccount}
+        className="mt-6 inline-flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium bg-[var(--accent-primary)] text-white hover:bg-[var(--accent-hover)] transition-colors cursor-pointer"
+      >
+        <PlusIcon className="w-4 h-4" />
+        Add Account
+      </button>
+    </div>
   );
 }

--- a/frontend/src/pages/Accounts.jsx
+++ b/frontend/src/pages/Accounts.jsx
@@ -21,7 +21,7 @@ export default function Accounts() {
   const { selectedPortfolioId } = usePortfolio();
   const {
     accounts, accountHoldings, totalValue,
-    loading, error, currency, refresh,
+    loading, error, currency, refresh, positionsTruncated,
   } = useAccountsData();
 
   const [selectedAccount, setSelectedAccount] = useState(null);
@@ -145,6 +145,13 @@ export default function Accounts() {
           Add Account
         </button>
       </div>
+
+      {/* Positions truncated warning */}
+      {positionsTruncated && (
+        <div className="mb-4 px-4 py-2.5 rounded-lg bg-[var(--warning)]/10 border border-[var(--warning)]/30 text-[12px] text-[var(--warning)]">
+          Portfolio has more than 100 positions — holdings data shown here is partial. Open an account to see its full breakdown.
+        </div>
+      )}
 
       {/* Allocation strip */}
       {accounts.length > 0 && (

--- a/frontend/src/pages/Accounts.jsx
+++ b/frontend/src/pages/Accounts.jsx
@@ -8,7 +8,6 @@
  */
 
 import { useState, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
 import { api } from '../lib';
 import { usePortfolio } from '../contexts';
 import { useAccountsData } from '../hooks/useAccountsData';
@@ -16,13 +15,9 @@ import { PageContainer } from '../components/layout';
 import { Skeleton } from '../components/ui';
 import { AllocationStrip, AccountGrid, AccountSidebar } from '../components/accounts';
 import { AccountWizard } from '../components/AccountWizard';
-import { ApiCredentialsModal } from '../components/ApiCredentialsModal';
-import { BatchUploadModal } from '../components/BatchUploadModal';
-import { getBrokerConfig } from '../components/AccountWizard/constants/brokerConfig';
 import { PlusIcon } from '../components/accounts/icons';
 
 export default function Accounts() {
-  const navigate = useNavigate();
   const { selectedPortfolioId } = usePortfolio();
   const {
     accounts, accountHoldings, totalValue,
@@ -31,10 +26,6 @@ export default function Accounts() {
 
   const [selectedAccount, setSelectedAccount] = useState(null);
   const [showWizard, setShowWizard] = useState(false);
-  const [showApiCredentials, setShowApiCredentials] = useState(false);
-  const [showBatchUpload, setShowBatchUpload] = useState(false);
-  const [activeModalAccount, setActiveModalAccount] = useState(null);
-  const [apiHasCredentials, setApiHasCredentials] = useState(false);
   const [linkableAccounts, setLinkableAccounts] = useState([]);
 
   // Derive live account from accounts array to avoid stale snapshot after refresh
@@ -85,28 +76,6 @@ export default function Accounts() {
       throw new Error(data.message || 'Failed to rename account');
     }
     refresh();
-  };
-
-  const handleUpload = (account) => {
-    setActiveModalAccount(account);
-    setShowBatchUpload(true);
-  };
-
-  // Fetches real credentials status before opening the modal so the modal
-  // shows the correct state (connected vs. entry form).
-  const handleApiCredentials = async (account) => {
-    setActiveModalAccount(account);
-    setApiHasCredentials(false);
-    try {
-      const res = await api(`/brokers/${account.broker_type}/credentials/${account.id}`);
-      if (res.ok) {
-        const data = await res.json();
-        setApiHasCredentials(data.has_credentials ?? false);
-      }
-    } catch {
-      // leave as false; modal will show the entry form
-    }
-    setShowApiCredentials(true);
   };
 
   if (loading) {
@@ -198,8 +167,6 @@ export default function Accounts() {
         onClose={handleCloseSidebar}
         onDelete={handleDelete}
         onRename={handleRename}
-        onUpload={handleUpload}
-        onApiCredentials={handleApiCredentials}
       />
 
       {/* Account creation wizard */}
@@ -212,42 +179,6 @@ export default function Accounts() {
         portfolioId={selectedPortfolioId}
         linkableAccounts={linkableAccounts}
         existingAccountNames={accounts.map((a) => a.name)}
-      />
-
-      {/* Batch upload modal — conditionally rendered so sessionId resets on each open.
-          onComplete fires only on successful import. */}
-      {showBatchUpload && (
-        <BatchUploadModal
-          isOpen={showBatchUpload}
-          onClose={() => {
-            setShowBatchUpload(false);
-            setActiveModalAccount(null);
-          }}
-          onComplete={() => {
-            setShowBatchUpload(false);
-            setActiveModalAccount(null);
-            refresh();
-          }}
-          accountId={activeModalAccount?.id}
-          brokerType={activeModalAccount?.broker_type}
-          supportedFormats={getBrokerConfig(activeModalAccount?.broker_type)?.supportedFormats || []}
-        />
-      )}
-
-      {/* API credentials modal */}
-      <ApiCredentialsModal
-        isOpen={showApiCredentials}
-        onClose={() => {
-          setShowApiCredentials(false);
-          setActiveModalAccount(null);
-        }}
-        account={activeModalAccount}
-        onCredentialsSaved={refresh}
-        hasCredentials={apiHasCredentials}
-        onGoToSettings={() => {
-          setShowApiCredentials(false);
-          navigate(`/accounts/${activeModalAccount?.id}`);
-        }}
       />
     </PageContainer>
   );

--- a/frontend/src/pages/Accounts.jsx
+++ b/frontend/src/pages/Accounts.jsx
@@ -5,7 +5,6 @@
  * - GET /api/accounts
  * - GET /api/dashboard/summary
  * - GET /api/positions
- * - GET /api/broker-data/supported-brokers
  */
 
 import { useState, useEffect } from 'react';
@@ -16,18 +15,29 @@ import { PageContainer } from '../components/layout';
 import { Skeleton } from '../components/ui';
 import { AllocationStrip, AccountGrid, AccountSidebar } from '../components/accounts';
 import { AccountWizard } from '../components/AccountWizard';
+import { ApiCredentialsModal } from '../components/ApiCredentialsModal';
+import { BatchUploadModal } from '../components/BatchUploadModal';
+import { getBrokerConfig } from '../components/AccountWizard/constants/brokerConfig';
 import { PlusIcon } from '../components/accounts/icons';
 
 export default function Accounts() {
   const { selectedPortfolioId } = usePortfolio();
   const {
     accounts, accountHoldings, totalValue,
-    loading, error, currency, refresh,
+    loading, error, currency, refresh, positionsTruncated,
   } = useAccountsData();
 
   const [selectedAccount, setSelectedAccount] = useState(null);
   const [showWizard, setShowWizard] = useState(false);
+  const [showApiCredentials, setShowApiCredentials] = useState(false);
+  const [showBatchUpload, setShowBatchUpload] = useState(false);
+  const [activeModalAccount, setActiveModalAccount] = useState(null);
   const [linkableAccounts, setLinkableAccounts] = useState([]);
+
+  // Derive live account from accounts array to avoid stale snapshot after refresh
+  const liveSelectedAccount = selectedAccount
+    ? accounts.find((a) => a.id === selectedAccount.id) ?? null
+    : null;
 
   // Fetch linkable accounts when wizard opens
   useEffect(() => {
@@ -42,6 +52,32 @@ export default function Accounts() {
   const handleCardClick = (account) => setSelectedAccount(account);
   const handleCloseSidebar = () => setSelectedAccount(null);
   const handleAddAccount = () => setShowWizard(true);
+
+  const handleDelete = async (accountId) => {
+    const res = await api(`/accounts/${accountId}`, { method: 'DELETE' });
+    if (res.ok) {
+      setSelectedAccount(null);
+      refresh();
+    }
+  };
+
+  const handleRename = async (accountId, newName) => {
+    const res = await api(`/accounts/${accountId}`, {
+      method: 'PUT',
+      body: JSON.stringify({ name: newName }),
+    });
+    if (res.ok) refresh();
+  };
+
+  const handleUpload = (account) => {
+    setActiveModalAccount(account);
+    setShowBatchUpload(true);
+  };
+
+  const handleApiCredentials = (account) => {
+    setActiveModalAccount(account);
+    setShowApiCredentials(true);
+  };
 
   if (loading) {
     return (
@@ -111,7 +147,7 @@ export default function Accounts() {
         />
       )}
 
-      {/* Account grid (handles empty state internally via add-account card) */}
+      {/* Account grid */}
       {accounts.length === 0 ? (
         <EmptyState onAddAccount={handleAddAccount} />
       ) : (
@@ -126,10 +162,15 @@ export default function Accounts() {
 
       {/* Account detail sidebar */}
       <AccountSidebar
-        account={selectedAccount}
-        holdings={selectedAccount ? accountHoldings.get(selectedAccount.id) || [] : []}
+        account={liveSelectedAccount}
+        holdings={liveSelectedAccount ? accountHoldings.get(liveSelectedAccount.id) || [] : []}
         currency={currency}
         onClose={handleCloseSidebar}
+        onDelete={handleDelete}
+        onRename={handleRename}
+        onUpload={handleUpload}
+        onApiCredentials={handleApiCredentials}
+        positionsTruncated={positionsTruncated}
       />
 
       {/* Account creation wizard */}
@@ -142,6 +183,31 @@ export default function Accounts() {
         portfolioId={selectedPortfolioId}
         linkableAccounts={linkableAccounts}
         existingAccountNames={accounts.map((a) => a.name)}
+      />
+
+      {/* Batch upload modal */}
+      <BatchUploadModal
+        isOpen={showBatchUpload}
+        onClose={() => {
+          setShowBatchUpload(false);
+          setActiveModalAccount(null);
+          refresh();
+        }}
+        accountId={activeModalAccount?.id}
+        brokerType={activeModalAccount?.broker_type}
+        supportedFormats={getBrokerConfig(activeModalAccount?.broker_type)?.supportedFormats || []}
+      />
+
+      {/* API credentials modal */}
+      <ApiCredentialsModal
+        isOpen={showApiCredentials}
+        onClose={() => {
+          setShowApiCredentials(false);
+          setActiveModalAccount(null);
+        }}
+        account={activeModalAccount}
+        onCredentialsSaved={refresh}
+        hasCredentials={false}
       />
     </PageContainer>
   );

--- a/frontend/src/pages/Accounts.jsx
+++ b/frontend/src/pages/Accounts.jsx
@@ -26,7 +26,7 @@ export default function Accounts() {
   const { selectedPortfolioId } = usePortfolio();
   const {
     accounts, accountHoldings, totalValue,
-    loading, error, currency, refresh, positionsTruncated,
+    loading, error, currency, refresh,
   } = useAccountsData();
 
   const [selectedAccount, setSelectedAccount] = useState(null);
@@ -200,7 +200,6 @@ export default function Accounts() {
         onRename={handleRename}
         onUpload={handleUpload}
         onApiCredentials={handleApiCredentials}
-        positionsTruncated={positionsTruncated}
       />
 
       {/* Account creation wizard */}

--- a/frontend/src/pages/Accounts.jsx
+++ b/frontend/src/pages/Accounts.jsx
@@ -149,7 +149,7 @@ export default function Accounts() {
       {/* Positions truncated warning */}
       {positionsTruncated && (
         <div className="mb-4 px-4 py-2.5 rounded-lg bg-[var(--warning)]/10 border border-[var(--warning)]/30 text-[12px] text-[var(--warning)]">
-          Portfolio has more than 100 positions — holdings data shown here is partial. Open an account to see its full breakdown.
+          Portfolio has more than 100 positions — holdings and allocation shown here are partial. Open an account's full details to see its complete holdings.
         </div>
       )}
 

--- a/frontend/src/pages/Accounts.jsx
+++ b/frontend/src/pages/Accounts.jsx
@@ -8,6 +8,7 @@
  */
 
 import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { api } from '../lib';
 import { usePortfolio } from '../contexts';
 import { useAccountsData } from '../hooks/useAccountsData';
@@ -21,6 +22,7 @@ import { getBrokerConfig } from '../components/AccountWizard/constants/brokerCon
 import { PlusIcon } from '../components/accounts/icons';
 
 export default function Accounts() {
+  const navigate = useNavigate();
   const { selectedPortfolioId } = usePortfolio();
   const {
     accounts, accountHoldings, totalValue,
@@ -32,6 +34,7 @@ export default function Accounts() {
   const [showApiCredentials, setShowApiCredentials] = useState(false);
   const [showBatchUpload, setShowBatchUpload] = useState(false);
   const [activeModalAccount, setActiveModalAccount] = useState(null);
+  const [apiHasCredentials, setApiHasCredentials] = useState(false);
   const [linkableAccounts, setLinkableAccounts] = useState([]);
 
   // Derive live account from accounts array to avoid stale snapshot after refresh
@@ -53,20 +56,35 @@ export default function Accounts() {
   const handleCloseSidebar = () => setSelectedAccount(null);
   const handleAddAccount = () => setShowWizard(true);
 
+  // Throws on failure so the sidebar can surface the error to the user.
+  // Uses unlink endpoint for accounts shared across multiple portfolios.
   const handleDelete = async (accountId) => {
-    const res = await api(`/accounts/${accountId}`, { method: 'DELETE' });
-    if (res.ok) {
-      setSelectedAccount(null);
-      refresh();
+    const account = accounts.find((a) => a.id === accountId);
+    const isShared = (account?.portfolio_ids?.length ?? 0) > 1;
+    const endpoint = isShared && selectedPortfolioId
+      ? `/portfolios/${selectedPortfolioId}/accounts/${accountId}`
+      : `/accounts/${accountId}`;
+
+    const res = await api(endpoint, { method: 'DELETE' });
+    if (!res.ok) {
+      const data = await res.json().catch(() => ({}));
+      throw new Error(data.message || 'Failed to delete account');
     }
+    setSelectedAccount(null);
+    refresh();
   };
 
+  // Throws on failure so the sidebar can surface the error to the user.
   const handleRename = async (accountId, newName) => {
     const res = await api(`/accounts/${accountId}`, {
       method: 'PUT',
       body: JSON.stringify({ name: newName }),
     });
-    if (res.ok) refresh();
+    if (!res.ok) {
+      const data = await res.json().catch(() => ({}));
+      throw new Error(data.message || 'Failed to rename account');
+    }
+    refresh();
   };
 
   const handleUpload = (account) => {
@@ -74,8 +92,20 @@ export default function Accounts() {
     setShowBatchUpload(true);
   };
 
-  const handleApiCredentials = (account) => {
+  // Fetches real credentials status before opening the modal so the modal
+  // shows the correct state (connected vs. entry form).
+  const handleApiCredentials = async (account) => {
     setActiveModalAccount(account);
+    setApiHasCredentials(false);
+    try {
+      const res = await api(`/brokers/${account.broker_type}/credentials/${account.id}`);
+      if (res.ok) {
+        const data = await res.json();
+        setApiHasCredentials(data.has_credentials ?? false);
+      }
+    } catch {
+      // leave as false; modal will show the entry form
+    }
     setShowApiCredentials(true);
   };
 
@@ -185,10 +215,14 @@ export default function Accounts() {
         existingAccountNames={accounts.map((a) => a.name)}
       />
 
-      {/* Batch upload modal */}
+      {/* Batch upload modal — onComplete fires only on successful import */}
       <BatchUploadModal
         isOpen={showBatchUpload}
         onClose={() => {
+          setShowBatchUpload(false);
+          setActiveModalAccount(null);
+        }}
+        onComplete={() => {
           setShowBatchUpload(false);
           setActiveModalAccount(null);
           refresh();
@@ -207,7 +241,11 @@ export default function Accounts() {
         }}
         account={activeModalAccount}
         onCredentialsSaved={refresh}
-        hasCredentials={false}
+        hasCredentials={apiHasCredentials}
+        onGoToSettings={() => {
+          setShowApiCredentials(false);
+          navigate(`/accounts/${activeModalAccount?.id}`);
+        }}
       />
     </PageContainer>
   );

--- a/frontend/src/pages/Accounts.jsx
+++ b/frontend/src/pages/Accounts.jsx
@@ -155,6 +155,7 @@ export default function Accounts() {
           accountHoldings={accountHoldings}
           currency={currency}
           onCardClick={handleCardClick}
+          onDelete={handleDelete}
           onAddAccount={handleAddAccount}
         />
       )}
@@ -165,7 +166,6 @@ export default function Accounts() {
         holdings={liveSelectedAccount ? accountHoldings.get(liveSelectedAccount.id) || [] : []}
         currency={currency}
         onClose={handleCloseSidebar}
-        onDelete={handleDelete}
         onRename={handleRename}
       />
 


### PR DESCRIPTION
## Summary

- Replace monolithic `Accounts.jsx` (900 lines) with a grid-card layout matching the accounts-playground mock
- New `useAccountsData` hook fetches accounts + dashboard summary + positions in parallel, enriching each account with value, allocation %, sync status, and per-account holdings (pivoted from the positions endpoint — no N+1 calls)
- New component directory `components/accounts/`: `AllocationStrip`, `AccountCard`, `AccountGrid`, `AccountSidebar`, `constants`, `icons`
- AccountWizard integration preserved; slide-over sidebar matches `TransactionDetailSidebar` pattern

## Test plan

- [ ] Grid cards render with broker logo, value, allocation %, top holdings pills, sync dot
- [ ] Allocation strip shows stacked bar + per-account badges
- [ ] Clicking a card opens the sidebar with summary + holdings list + P&L
- [ ] "View Details" in sidebar navigates to `/accounts/:id`
- [ ] "Add Account" button and dashed placeholder card open AccountWizard
- [ ] Wizard close triggers data refresh
- [ ] Loading skeletons display while fetching
- [ ] Empty state shows when no accounts exist
- [ ] Error state shows with retry button

Closes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)