### PR TITLE
feat: rebuild Assets page into componentized architecture

### DIFF
--- a/docs/plans/2026-04-07-assets-page.md
+++ b/docs/plans/2026-04-07-assets-page.md
@@ -1,0 +1,155 @@
+# Assets Page Implementation Plan
+
+**Issue:** #126
+**Branch:** `feat/assets-page`
+**Mock:** `mocks/assets-playground.html`
+
+## Overview
+
+Rebuild the Assets page from the existing monolithic `Assets.jsx` into a componentized architecture
+matching the finalized mock. The Assets page is a **global market catalog** showing all known assets
+(not just user-held positions) with market data, sorting, filtering, and an asset detail sidebar.
+
+## Key Distinction
+
+- **Assets page** = global catalog of all system assets with market data (price, change, mkt cap, volume, sparkline)
+- **Holdings page** = user's portfolio positions with cost basis and P&L
+- A "portfolio badge" on the Asset column indicates which assets the user holds
+
+## Architecture
+
+```
+Assets.jsx (page)
+  +-- AssetClassTabs          (segmented control: All/Crypto/Stocks/ETFs/Forex)
+  +-- AssetsFilterRow          (search input + time period toggle + favorites toggle)
+  +-- AssetsTable              (table wrapper with header + body + footer)
+  |     +-- AssetRow           (per-asset row with star, icon, price, change, sparkline)
+  |     +-- SparklineCell      (80x28 inline SVG sparkline)
+  +-- AssetDetailSidebar       (shared from dashboard -- already exists)
+```
+
+## Data Flow
+
+1. `useAssetsData` hook fetches:
+   - `GET /api/assets/market?display_currency={cur}&limit=500` -> all assets with change data
+   - `GET /api/positions?display_currency={cur}&portfolio_id={pid}` -> user holdings (for portfolio badge)
+2. Positions are indexed by `asset_id` into a Map for O(1) lookup
+3. Filtering (asset class, search, favorites) and sorting happen client-side on the full dataset
+4. Sparklines are procedurally generated from change data (same approach as mock)
+
+## Implementation Tasks
+
+### Task 1: useAssetsData Hook
+**File:** `frontend/src/hooks/useAssetsData.js`
+
+- Fetch from `/api/assets/market` with `display_currency` from PortfolioContext
+- Fetch from `/api/positions` with `portfolio_id` from PortfolioContext
+- Return `{ assets, positions, loading, error, currency, toggleFavorite }`
+- `positions` is a Map keyed by `asset_id` for O(1) lookup
+- `toggleFavorite(assetId)` calls `PUT /api/assets/{id}/favorite` with optimistic update
+
+### Task 2: Page-Specific Components
+**Directory:** `frontend/src/components/assets/`
+
+#### AssetClassTabs.jsx
+- Props: `tabs, activeTab, onTabChange`
+- Segmented control with count badges
+- Active tab: `bg-[var(--bg-secondary)]` with accent badge
+- Inactive tab: `bg-transparent`, `text-[var(--text-tertiary)]`
+
+#### AssetsFilterRow.jsx
+- Props: `searchQuery, onSearchChange, selectedPeriod, onPeriodChange, showFavoritesOnly, onFavoritesToggle`
+- Left: search input (240px) with magnifying glass icon
+- Right: time period toggle (1D/1W/1M/1Y pills) + favorites toggle button
+- Active period pill: `bg-[var(--accent-primary)] text-white`
+- Active favorites: amber highlight with filled star
+
+#### AssetsTable.jsx
+- Props: `assets, positions, timePeriod, currency, sortConfig, onSort, onRowClick, onToggleFavorite`
+- 7 columns: Star (40px), Asset (auto), Price (120px), Change (140px), Mkt Cap (120px), Volume (100px), Trend (100px)
+- Sortable columns: symbol, price, changePct, marketCap, volume
+- Footer: "Showing X of Y assets" with favorites count
+
+#### AssetRow.jsx
+- Props: `asset, position, timePeriod, currency, onToggleFavorite, onClick`
+- Star toggle, colored icon circle, symbol+name+portfolio badge, price, change with indicator, mkt cap, volume, sparkline
+- All numbers use `font-mono tabular-nums`
+- Change colors: `text-[var(--positive)]` / `text-[var(--negative)]`
+
+#### SparklineCell.jsx
+- Props: `assetId, periodIndex, changePct`
+- 80x28 SVG with cubic bezier path
+- Stroke color matches change direction (positive/negative/neutral)
+- Deterministic pseudo-random from seed (assetId + periodIndex)
+
+#### icons.jsx
+- MagnifyingGlassIcon, StarOutlineIcon, StarFilledIcon, BriefcaseIcon, SortIcon
+
+### Task 3: Rewrite Assets.jsx
+**File:** `frontend/src/pages/Assets.jsx`
+
+- Import PageContainer from layout
+- Wire useAssetsData hook
+- Client-side filtering: asset class tabs, search (debounced), favorites toggle
+- Client-side sorting with sort config state
+- Loading skeleton matching table layout
+- Error state with retry button
+- Empty state when no assets match filters
+
+### Task 4: Wire AssetDetailSidebar
+- Import shared `AssetDetailSidebar` from `../components/dashboard`
+- On row click, construct payload via `toAssetClickPayload`-style mapping
+- Pass `onFavoriteToggle` for sidebar star sync
+
+## CSS Token Mapping (Mock -> App)
+
+| Mock Token | App Token |
+|-----------|-----------|
+| `--bg-base` | `--bg-primary` |
+| `--bg-card` | `--bg-secondary` |
+| `--bg-card-hover` | `--bg-tertiary` |
+| `--bg-elevated` | `--bg-tertiary` |
+| `--border` | `--border-primary` |
+| `--border-subtle` | `--border-subtle` |
+| `--text-primary` | `--text-primary` |
+| `--text-secondary` | `--text-secondary` |
+| `--text-muted` | `--text-tertiary` |
+| `--text-faint` | `--text-faint` |
+| `--accent` | `--accent-primary` |
+| `--accent-hover` | `--accent-hover` |
+| `--accent-muted` | `accent-primary` with opacity |
+| `--positive` | `--positive` |
+| `--negative` | `--negative` |
+| `--warning` | `--amber` |
+
+## API Field Mapping
+
+The `/api/assets/market` response already includes: `change_1d`, `change_1d_pct`, `change_1w`,
+`change_1w_pct`, `change_1m`, `change_1m_pct`. It does NOT include `change_1y`, `market_cap`,
+or `volume`.
+
+**For this PR:** Display mkt cap and volume from the `/api/assets/{id}/detail` endpoint's
+`daily_metrics` if available. Since the market endpoint doesn't include these yet, show them
+as "--" in the table for assets without detail data. The mock's 1Y period will also show "--"
+for change values. Backend enrichment is a follow-up task.
+
+## File Changes Summary
+
+| File | Action |
+|------|--------|
+| `frontend/src/hooks/useAssetsData.js` | Create |
+| `frontend/src/components/assets/index.js` | Create |
+| `frontend/src/components/assets/AssetClassTabs.jsx` | Create |
+| `frontend/src/components/assets/AssetsFilterRow.jsx` | Create |
+| `frontend/src/components/assets/AssetsTable.jsx` | Create |
+| `frontend/src/components/assets/AssetRow.jsx` | Create |
+| `frontend/src/components/assets/SparklineCell.jsx` | Create |
+| `frontend/src/components/assets/icons.jsx` | Create |
+| `frontend/src/pages/Assets.jsx` | Rewrite |
+
+## Out of Scope (Follow-up)
+
+- Backend: Add `change_1y` / `change_1y_pct` to AssetMarketResponse
+- Backend: Add `market_cap` and `volume` to AssetMarketResponse
+- Backend: Optional sparkline data array in market response
+- Mobile responsive layout

--- a/frontend/src/components/assets/AssetClassTabs.jsx
+++ b/frontend/src/components/assets/AssetClassTabs.jsx
@@ -1,0 +1,49 @@
+import { cn } from '../../lib';
+
+const ASSET_CLASSES = ['All', 'Crypto', 'Stock', 'ETF', 'Cash'];
+const ASSET_CLASS_LABELS = {
+  All: 'All',
+  Crypto: 'Crypto',
+  Stock: 'Stocks',
+  ETF: 'ETFs',
+  Cash: 'Forex',
+};
+
+export function AssetClassTabs({ assets, activeTab, onTabChange }) {
+  const counts = { All: assets.length };
+  for (const asset of assets) {
+    counts[asset.asset_class] = (counts[asset.asset_class] || 0) + 1;
+  }
+
+  const visibleTabs = ASSET_CLASSES.filter((cls) => cls === 'All' || counts[cls] > 0);
+
+  return (
+    <div className="flex items-center gap-0.5 p-[3px] bg-[var(--bg-tertiary)] rounded-[10px] mb-4 overflow-x-auto">
+      {visibleTabs.map((cls) => (
+        <button
+          key={cls}
+          onClick={() => onTabChange(cls)}
+          className={cn(
+            'flex items-center gap-1.5 px-3.5 py-2 rounded-lg text-[13px] font-medium cursor-pointer',
+            'transition-all whitespace-nowrap border-none',
+            activeTab === cls
+              ? 'bg-[var(--bg-secondary)] text-[var(--text-primary)] font-semibold shadow-sm'
+              : 'bg-transparent text-[var(--text-tertiary)] hover:text-[var(--text-secondary)]'
+          )}
+        >
+          {ASSET_CLASS_LABELS[cls] || cls}
+          <span
+            className={cn(
+              'text-[11px] px-[7px] py-px rounded-[10px] font-semibold tabular-nums',
+              activeTab === cls
+                ? 'bg-[var(--accent-primary)]/15 text-[var(--accent-primary)]'
+                : 'bg-[var(--bg-secondary)] text-[var(--text-faint)]'
+            )}
+          >
+            {counts[cls]}
+          </span>
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/assets/AssetRow.jsx
+++ b/frontend/src/components/assets/AssetRow.jsx
@@ -29,7 +29,7 @@ export function AssetRow({ asset, position, period, currency, onToggleFavorite, 
   const changeAbs = asset[keys.change];
   const isPositive = changePct > 0;
   const isNegative = changePct < 0;
-  const iconColor = ICON_COLORS[asset.asset_class] || '#64748B';
+  const iconColor = ICON_COLORS[asset.asset_class] || 'var(--slate-clr)';
   const initials = (asset.symbol || '??').slice(0, 2);
 
   return (
@@ -43,7 +43,7 @@ export function AssetRow({ asset, position, period, currency, onToggleFavorite, 
           onClick={(e) => { e.stopPropagation(); onToggleFavorite(asset.id); }}
           className={cn(
             'text-[16px] leading-none p-0.5 cursor-pointer transition-colors bg-transparent border-none',
-            asset.is_favorite ? 'text-[#F59E0B]' : 'text-[var(--text-faint)] hover:text-[#F59E0B]'
+            asset.is_favorite ? 'text-[var(--amber)]' : 'text-[var(--text-faint)] hover:text-[var(--amber)]'
           )}
         >
           {asset.is_favorite ? (
@@ -121,7 +121,7 @@ export function AssetRow({ asset, position, period, currency, onToggleFavorite, 
               {changeAbs >= 0 ? '+' : ''}
               {Math.abs(changeAbs) >= 1
                 ? formatCurrency(changeAbs, currency, { decimals: 2 })
-                : `$${changeAbs.toFixed(4)}`}
+                : `${changeAbs < 0 ? '-' : ''}$${Math.abs(changeAbs).toFixed(4)}`}
             </span>
           )}
         </div>

--- a/frontend/src/components/assets/AssetRow.jsx
+++ b/frontend/src/components/assets/AssetRow.jsx
@@ -130,7 +130,7 @@ export function AssetRow({ asset, position, period, currency, onToggleFavorite, 
       {/* Market Cap */}
       <td className="px-4 py-3 text-right w-[120px]">
         <span className="font-mono tabular-nums text-[13px] text-[var(--text-secondary)]">
-          {position?.market_cap ? formatCompact(position.market_cap) : '\u2014'}
+          {asset.market_cap != null ? formatCompact(asset.market_cap) : '\u2014'}
         </span>
       </td>
 

--- a/frontend/src/components/assets/AssetRow.jsx
+++ b/frontend/src/components/assets/AssetRow.jsx
@@ -1,0 +1,152 @@
+import { cn, formatCurrency, getChangeIndicator, ASSET_COLORS } from '../../lib';
+import { StarOutlineIcon, StarFilledIcon, BriefcaseIcon } from './icons';
+import { SparklineCell } from './SparklineCell';
+import { PERIOD_KEYS } from './constants';
+
+// Extend shared ASSET_COLORS with the "Stock" alias used in asset data
+const ICON_COLORS = { ...ASSET_COLORS, Stock: '#3B82F6' };
+
+function formatCompact(value) {
+  if (value == null) return '\u2014';
+  if (value >= 1e12) return `$${(value / 1e12).toFixed(2)}T`;
+  if (value >= 1e9) return `$${(value / 1e9).toFixed(1)}B`;
+  if (value >= 1e6) return `$${(value / 1e6).toFixed(1)}M`;
+  if (value >= 1e3) return `$${(value / 1e3).toFixed(0)}K`;
+  return `$${value.toFixed(0)}`;
+}
+
+function formatPrice(value, currency) {
+  if (value == null) return '\u2014';
+  if (value >= 10000) return formatCurrency(value, currency, { decimals: 0 });
+  if (value >= 1) return formatCurrency(value, currency, { decimals: 2 });
+  if (value >= 0.01) return formatCurrency(value, currency, { decimals: 4 });
+  return formatCurrency(value, currency, { decimals: 6 });
+}
+
+export function AssetRow({ asset, position, period, currency, onToggleFavorite, onClick }) {
+  const keys = PERIOD_KEYS[period] || PERIOD_KEYS['1d'];
+  const changePct = asset[keys.pct];
+  const changeAbs = asset[keys.change];
+  const isPositive = changePct > 0;
+  const isNegative = changePct < 0;
+  const iconColor = ICON_COLORS[asset.asset_class] || '#64748B';
+  const initials = (asset.symbol || '??').slice(0, 2);
+
+  return (
+    <tr
+      onClick={() => onClick(asset)}
+      className="hover:bg-[var(--bg-tertiary)] transition-colors cursor-pointer group"
+    >
+      {/* Star */}
+      <td className="px-4 py-3 w-[40px]">
+        <button
+          onClick={(e) => { e.stopPropagation(); onToggleFavorite(asset.id); }}
+          className={cn(
+            'text-[16px] leading-none p-0.5 cursor-pointer transition-colors bg-transparent border-none',
+            asset.is_favorite ? 'text-[#F59E0B]' : 'text-[var(--text-faint)] hover:text-[#F59E0B]'
+          )}
+        >
+          {asset.is_favorite ? (
+            <StarFilledIcon className="w-4 h-4" />
+          ) : (
+            <StarOutlineIcon className="w-4 h-4" />
+          )}
+        </button>
+      </td>
+
+      {/* Asset */}
+      <td className="px-4 py-3">
+        <div className="flex items-center gap-2.5">
+          <div
+            className="w-8 h-8 rounded-lg flex-shrink-0 flex items-center justify-center text-[11px] font-bold text-white"
+            style={{ backgroundColor: iconColor }}
+          >
+            {initials}
+          </div>
+          <div className="min-w-0">
+            <div className="flex items-center gap-1.5">
+              <span className="font-semibold text-[13px] text-[var(--text-primary)]">{asset.symbol}</span>
+              {position && (
+                <span
+                  className="inline-flex items-center justify-center w-[18px] h-[18px] rounded-full bg-[var(--accent-primary)]/15 flex-shrink-0"
+                  title="In your portfolio"
+                >
+                  <BriefcaseIcon className="w-[10px] h-[10px] text-[var(--accent-primary)]" />
+                </span>
+              )}
+            </div>
+            <p className="text-[12px] text-[var(--text-faint)] mt-px truncate max-w-[220px]">
+              {asset.name}
+            </p>
+          </div>
+        </div>
+      </td>
+
+      {/* Price */}
+      <td className="px-4 py-3 text-right w-[120px]">
+        <span className="font-mono tabular-nums text-[13px] text-[var(--text-primary)]">
+          {formatPrice(asset.last_fetched_price, asset.currency)}
+        </span>
+      </td>
+
+      {/* Change */}
+      <td className="px-4 py-3 text-right w-[140px]">
+        <div className="flex flex-col items-end">
+          <span
+            className={cn(
+              'text-[13px] font-semibold font-mono tabular-nums flex items-center gap-[3px]',
+              isPositive && 'text-[var(--positive)]',
+              isNegative && 'text-[var(--negative)]',
+              !isPositive && !isNegative && 'text-[var(--text-tertiary)]'
+            )}
+          >
+            {changePct != null ? (
+              <>
+                <span className="text-[10px]">
+                  {getChangeIndicator(changePct)}
+                </span>
+                {changePct > 0 ? '+' : ''}{changePct.toFixed(2)}%
+              </>
+            ) : '\u2014'}
+          </span>
+          {changeAbs != null && (
+            <span
+              className={cn(
+                'text-[11px] font-mono tabular-nums mt-px',
+                isPositive && 'text-[var(--positive)]',
+                isNegative && 'text-[var(--negative)]',
+                !isPositive && !isNegative && 'text-[var(--text-tertiary)]'
+              )}
+            >
+              {changeAbs >= 0 ? '+' : ''}
+              {Math.abs(changeAbs) >= 1
+                ? formatCurrency(changeAbs, currency, { decimals: 2 })
+                : `$${changeAbs.toFixed(4)}`}
+            </span>
+          )}
+        </div>
+      </td>
+
+      {/* Market Cap */}
+      <td className="px-4 py-3 text-right w-[120px]">
+        <span className="font-mono tabular-nums text-[13px] text-[var(--text-secondary)]">
+          {position?.market_cap ? formatCompact(position.market_cap) : '\u2014'}
+        </span>
+      </td>
+
+      {/* Volume */}
+      <td className="px-4 py-3 text-right w-[100px] font-mono tabular-nums text-[13px] text-[var(--text-secondary)]">
+        {'\u2014'}
+      </td>
+
+      {/* Sparkline */}
+      <td className="px-4 py-3 text-right w-[100px]">
+        <SparklineCell
+          assetId={asset.id}
+          changePct={changePct}
+          period={period}
+        />
+      </td>
+    </tr>
+  );
+}

--- a/frontend/src/components/assets/AssetsFilterRow.jsx
+++ b/frontend/src/components/assets/AssetsFilterRow.jsx
@@ -1,0 +1,71 @@
+import { cn } from '../../lib';
+import { MagnifyingGlassIcon, StarOutlineIcon, StarFilledIcon } from './icons';
+
+const TIME_PERIODS = [
+  { id: '1d', label: '1D' },
+  { id: '1w', label: '1W' },
+  { id: '1m', label: '1M' },
+];
+
+export function AssetsFilterRow({
+  searchQuery,
+  onSearchChange,
+  selectedPeriod,
+  onPeriodChange,
+  showFavoritesOnly,
+  onFavoritesToggle,
+}) {
+  return (
+    <div className="flex items-center gap-2.5 mb-4 flex-wrap">
+      {/* Search */}
+      <div className="relative w-[240px] flex-shrink-0">
+        <MagnifyingGlassIcon className="absolute left-2.5 top-1/2 -translate-y-1/2 w-[15px] h-[15px] text-[var(--text-faint)] pointer-events-none" />
+        <input
+          type="text"
+          placeholder="Search assets..."
+          value={searchQuery}
+          onChange={(e) => onSearchChange(e.target.value)}
+          className="w-full py-2 pl-[34px] pr-3 bg-[var(--bg-tertiary)] border border-[var(--border-primary)] rounded-lg text-[13px] text-[var(--text-primary)] placeholder:text-[var(--text-faint)] focus:outline-none focus:border-[var(--accent-primary)] transition-colors"
+        />
+      </div>
+
+      <div className="flex-1" />
+
+      {/* Time period toggle */}
+      <div className="flex items-center gap-0.5 p-[3px] bg-[var(--bg-tertiary)] border border-[var(--border-primary)] rounded-lg">
+        {TIME_PERIODS.map((p) => (
+          <button
+            key={p.id}
+            onClick={() => onPeriodChange(p.id)}
+            className={cn(
+              'px-3 py-[5px] border-none rounded-md text-xs font-semibold cursor-pointer transition-all',
+              selectedPeriod === p.id
+                ? 'bg-[var(--accent-primary)] text-white'
+                : 'bg-transparent text-[var(--text-tertiary)] hover:text-[var(--text-secondary)]'
+            )}
+          >
+            {p.label}
+          </button>
+        ))}
+      </div>
+
+      {/* Favorites toggle */}
+      <button
+        onClick={onFavoritesToggle}
+        className={cn(
+          'flex items-center gap-1.5 px-3.5 py-[6px] rounded-lg text-[13px] font-medium cursor-pointer transition-all border',
+          showFavoritesOnly
+            ? 'bg-[var(--amber)]/12 border-[var(--amber)] text-[var(--amber)]'
+            : 'bg-[var(--bg-tertiary)] border-[var(--border-primary)] text-[var(--text-tertiary)] hover:border-[var(--text-faint)] hover:text-[var(--text-secondary)]'
+        )}
+      >
+        {showFavoritesOnly ? (
+          <StarFilledIcon className="w-[15px] h-[15px]" />
+        ) : (
+          <StarOutlineIcon className="w-[15px] h-[15px]" />
+        )}
+        Favorites
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/components/assets/AssetsTable.jsx
+++ b/frontend/src/components/assets/AssetsTable.jsx
@@ -1,0 +1,133 @@
+import { cn } from '../../lib';
+import { AssetRow } from './AssetRow';
+import { Skeleton } from '../ui';
+
+function SortArrow({ direction }) {
+  return (
+    <span className="text-[var(--accent-primary)] ml-[3px] text-[10px]">
+      {direction === 'asc' ? '\u25B2' : '\u25BC'}
+    </span>
+  );
+}
+
+function TableHeader({ label, sortKey, sortConfig, onSort, align = 'left', width, sortable = true }) {
+  const isActive = sortConfig.key === sortKey;
+  return (
+    <th
+      onClick={sortable ? () => onSort(sortKey) : undefined}
+      style={width ? { width } : undefined}
+      className={cn(
+        'px-4 py-2.5 text-[11px] font-semibold uppercase tracking-[0.5px] border-b border-[var(--border-primary)] whitespace-nowrap transition-colors',
+        align === 'right' ? 'text-right' : 'text-left',
+        sortable ? 'cursor-pointer select-none' : 'cursor-default',
+        isActive ? 'text-[var(--text-secondary)]' : 'text-[var(--text-faint)]',
+        sortable && 'hover:text-[var(--text-tertiary)]'
+      )}
+    >
+      {label}
+      {isActive && <SortArrow direction={sortConfig.direction} />}
+    </th>
+  );
+}
+
+function LoadingSkeleton() {
+  return (
+    <tbody>
+      {Array.from({ length: 10 }).map((_, i) => (
+        <tr key={i}>
+          <td className="px-4 py-3 w-[40px]"><Skeleton className="w-4 h-4" /></td>
+          <td className="px-4 py-3">
+            <div className="flex items-center gap-2.5">
+              <Skeleton className="w-8 h-8 rounded-lg" />
+              <div>
+                <Skeleton className="h-3.5 w-16 mb-1" />
+                <Skeleton className="h-3 w-28" />
+              </div>
+            </div>
+          </td>
+          <td className="px-4 py-3"><Skeleton className="h-3.5 w-20 ml-auto" /></td>
+          <td className="px-4 py-3">
+            <div className="flex flex-col items-end gap-1">
+              <Skeleton className="h-3.5 w-16" />
+              <Skeleton className="h-3 w-12" />
+            </div>
+          </td>
+          <td className="px-4 py-3"><Skeleton className="h-3.5 w-16 ml-auto" /></td>
+          <td className="px-4 py-3"><Skeleton className="h-3.5 w-14 ml-auto" /></td>
+          <td className="px-4 py-3"><Skeleton className="h-7 w-20 ml-auto" /></td>
+        </tr>
+      ))}
+    </tbody>
+  );
+}
+
+export function AssetsTable({
+  assets,
+  positionMap,
+  period,
+  currency,
+  sortConfig,
+  onSort,
+  onRowClick,
+  onToggleFavorite,
+  loading,
+  totalCount,
+  favoritesCount,
+}) {
+  return (
+    <div className="bg-[var(--bg-secondary)] border border-[var(--border-primary)] rounded-xl overflow-hidden">
+      <table className="w-full border-collapse">
+        <thead>
+          <tr>
+            <TableHeader label="" sortKey="" sortable={false} sortConfig={sortConfig} onSort={onSort} width="40px" />
+            <TableHeader label="Asset" sortKey="symbol" sortConfig={sortConfig} onSort={onSort} />
+            <TableHeader label="Price" sortKey="price" sortConfig={sortConfig} onSort={onSort} align="right" width="120px" />
+            <TableHeader label="Change" sortKey="changePct" sortConfig={sortConfig} onSort={onSort} align="right" width="140px" />
+            <TableHeader label="Mkt Cap" sortKey="marketCap" sortConfig={sortConfig} onSort={onSort} align="right" width="120px" />
+            <TableHeader label="Volume" sortKey="volume" sortable={false} sortConfig={sortConfig} onSort={onSort} align="right" width="100px" />
+            <TableHeader label="Trend" sortKey="" sortable={false} sortConfig={sortConfig} onSort={onSort} align="right" width="100px" />
+          </tr>
+        </thead>
+        {loading ? (
+          <LoadingSkeleton />
+        ) : (
+          <tbody>
+            {assets.map((asset) => (
+              <AssetRow
+                key={asset.id}
+                asset={asset}
+                position={positionMap.get(asset.id)}
+                period={period}
+                currency={currency}
+                onToggleFavorite={onToggleFavorite}
+                onClick={onRowClick}
+              />
+            ))}
+            {assets.length === 0 && (
+              <tr>
+                <td colSpan={7} className="px-4 py-16 text-center">
+                  <div className="text-[var(--text-faint)]">
+                    <p className="text-base font-semibold text-[var(--text-secondary)] mb-1.5">No assets found</p>
+                    <p className="text-[13px]">Try adjusting your search or filters</p>
+                  </div>
+                </td>
+              </tr>
+            )}
+          </tbody>
+        )}
+      </table>
+
+      {/* Footer */}
+      {!loading && assets.length > 0 && (
+        <div className="flex items-center justify-between px-4 py-3 border-t border-[var(--border-primary)] bg-[var(--bg-tertiary)] text-[12px] text-[var(--text-faint)]">
+          <span>
+            Showing {assets.length} of {totalCount} assets
+          </span>
+          {favoritesCount > 0 && (
+            <span>{favoritesCount} favorite{favoritesCount !== 1 ? 's' : ''}</span>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/assets/SparklineCell.jsx
+++ b/frontend/src/components/assets/SparklineCell.jsx
@@ -1,0 +1,52 @@
+const PERIOD_INDEX = { '1d': 0, '1w': 1, '1m': 2 };
+
+function seededRand(seed) {
+  let s = seed;
+  return function next() {
+    s = (s * 16807 + 0) % 2147483647;
+    return (s - 1) / 2147483646;
+  };
+}
+
+function generateSparkPath(assetId, periodIdx, changePct) {
+  const rand = seededRand(assetId * 17 + periodIdx * 31 + 7);
+  const w = 80;
+  const h = 28;
+  const pts = 12;
+  const step = w / (pts - 1);
+  const magnitude = Math.min(Math.abs(changePct) / 20, 1);
+  const dir = -Math.sign(changePct);
+
+  const points = [];
+  for (let i = 0; i < pts; i++) {
+    const t = i / (pts - 1);
+    const trend = dir * magnitude * t * (h * 0.6);
+    const noise = (rand() - 0.5) * h * 0.35;
+    const y = h / 2 + trend + noise;
+    points.push([i * step, Math.max(2, Math.min(h - 2, y))]);
+  }
+
+  let d = `M${points[0][0].toFixed(1)},${points[0][1].toFixed(1)}`;
+  for (let i = 1; i < points.length; i++) {
+    const prev = points[i - 1];
+    const curr = points[i];
+    const cpx = (prev[0] + curr[0]) / 2;
+    d += ` C${cpx.toFixed(1)},${prev[1].toFixed(1)} ${cpx.toFixed(1)},${curr[1].toFixed(1)} ${curr[0].toFixed(1)},${curr[1].toFixed(1)}`;
+  }
+  return d;
+}
+
+export function SparklineCell({ assetId, changePct, period }) {
+  const periodIdx = PERIOD_INDEX[period] ?? 0;
+  const pct = changePct ?? 0;
+  const path = generateSparkPath(assetId, periodIdx, pct);
+  let color = 'var(--text-tertiary)';
+  if (pct > 0) color = 'var(--positive)';
+  else if (pct < 0) color = 'var(--negative)';
+
+  return (
+    <svg width="80" height="28" viewBox="0 0 80 28" className="block">
+      <path d={path} fill="none" stroke={color} strokeWidth="1.5" strokeLinecap="round" />
+    </svg>
+  );
+}

--- a/frontend/src/components/assets/constants.js
+++ b/frontend/src/components/assets/constants.js
@@ -1,0 +1,5 @@
+export const PERIOD_KEYS = {
+  '1d': { change: 'change_1d', pct: 'change_1d_pct' },
+  '1w': { change: 'change_1w', pct: 'change_1w_pct' },
+  '1m': { change: 'change_1m', pct: 'change_1m_pct' },
+};

--- a/frontend/src/components/assets/icons.jsx
+++ b/frontend/src/components/assets/icons.jsx
@@ -1,0 +1,32 @@
+export function MagnifyingGlassIcon({ className }) {
+  return (
+    <svg className={className} fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
+      <path strokeLinecap="round" strokeLinejoin="round" d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z" />
+    </svg>
+  );
+}
+
+export function StarOutlineIcon({ className }) {
+  return (
+    <svg className={className} fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
+      <path strokeLinecap="round" strokeLinejoin="round" d="M11.48 3.499a.562.562 0 0 1 1.04 0l2.125 5.111a.563.563 0 0 0 .475.345l5.518.442c.499.04.701.663.321.988l-4.204 3.602a.563.563 0 0 0-.182.557l1.285 5.385a.562.562 0 0 1-.84.61l-4.725-2.885a.562.562 0 0 0-.586 0L6.982 20.54a.562.562 0 0 1-.84-.61l1.285-5.386a.562.562 0 0 0-.182-.557l-4.204-3.602a.562.562 0 0 1 .321-.988l5.518-.442a.563.563 0 0 0 .475-.345L11.48 3.5Z" />
+    </svg>
+  );
+}
+
+export function StarFilledIcon({ className }) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="currentColor">
+      <path fillRule="evenodd" d="M10.788 3.21c.448-1.077 1.976-1.077 2.424 0l2.082 5.006 5.404.434c1.164.093 1.636 1.545.749 2.305l-4.117 3.527 1.257 5.273c.271 1.136-.964 2.033-1.96 1.425L12 18.354 7.373 21.18c-.996.608-2.231-.29-1.96-1.425l1.257-5.273-4.117-3.527c-.887-.76-.415-2.212.749-2.305l5.404-.434 2.082-5.005Z" clipRule="evenodd" />
+    </svg>
+  );
+}
+
+export function BriefcaseIcon({ className }) {
+  return (
+    <svg className={className} viewBox="0 0 20 20" fill="currentColor">
+      <path fillRule="evenodd" d="M6 3.75A2.75 2.75 0 0 1 8.75 1h2.5A2.75 2.75 0 0 1 14 3.75v.443c.572.055 1.14.122 1.706.2C17.053 4.582 18 5.75 18 7.07v3.469c0 1.126-.694 2.191-1.83 2.54-1.952.599-4.024.921-6.17.921s-4.219-.322-6.17-.921C2.694 12.73 2 11.665 2 10.539V7.07c0-1.321.947-2.489 2.294-2.676A41.047 41.047 0 0 1 6 4.193V3.75Zm6.5 0v.325a41.622 41.622 0 0 0-5 0V3.75c0-.69.56-1.25 1.25-1.25h2.5c.69 0 1.25.56 1.25 1.25ZM10 10a1 1 0 0 0-1 1v.01a1 1 0 0 0 1 1h.01a1 1 0 0 0 1-1V11a1 1 0 0 0-1-1H10Z" clipRule="evenodd" />
+      <path d="M3 15.055v-.684c.126.053.255.1.39.142 2.092.642 4.313.987 6.61.987 2.297 0 4.518-.345 6.61-.987.135-.041.264-.089.39-.142v.684c0 1.347-.985 2.53-2.363 2.686a41.454 41.454 0 0 1-9.274 0C3.985 17.585 3 16.402 3 15.055Z" />
+    </svg>
+  );
+}

--- a/frontend/src/components/assets/index.js
+++ b/frontend/src/components/assets/index.js
@@ -1,0 +1,7 @@
+export { AssetClassTabs } from './AssetClassTabs';
+export { AssetsFilterRow } from './AssetsFilterRow';
+export { AssetsTable } from './AssetsTable';
+export { AssetRow } from './AssetRow';
+export { SparklineCell } from './SparklineCell';
+
+export { PERIOD_KEYS } from './constants';

--- a/frontend/src/components/dashboard/AssetDetailSidebar.jsx
+++ b/frontend/src/components/dashboard/AssetDetailSidebar.jsx
@@ -70,6 +70,11 @@ export function AssetDetailSidebar({ asset, isOpen, onClose, onFavoriteToggle })
 
   useSlideover(isOpen, onClose);
 
+  // Sync isFavorite from parent prop so table-side toggles (and their reverts) propagate live
+  useEffect(() => {
+    setIsFavorite(asset?.is_favorite ?? false);
+  }, [asset?.is_favorite]);
+
   // Fetch position details (account breakdown, P&L)
   useEffect(() => {
     if (!asset?.id || !isOpen) return;
@@ -214,7 +219,7 @@ export function AssetDetailSidebar({ asset, isOpen, onClose, onFavoriteToggle })
               </p>
             ) : dayChangePct != null && (
               <p className={cn('text-sm font-mono tabular-nums', changeColor)}>
-                {getChangeIndicator(dayChangePct)} {formatPercent(dayChangePct)}
+                {getChangeIndicator(dayChangePct)} ({formatPercent(dayChangePct)})
               </p>
             )}
           </div>

--- a/frontend/src/components/dashboard/AssetDetailSidebar.jsx
+++ b/frontend/src/components/dashboard/AssetDetailSidebar.jsx
@@ -83,7 +83,7 @@ export function AssetDetailSidebar({ asset, isOpen, onClose, onFavoriteToggle })
         const items = res.items || res || [];
         const match = items.find((p) => p.asset_id === asset.id);
         setPosition(match || null);
-        setIsFavorite(match?.is_favorite ?? false);
+        setIsFavorite(match?.is_favorite ?? asset.is_favorite ?? false);
       })
       .catch(() => { if (!cancelled) setPosition(null); })
       .finally(() => { if (!cancelled) setPosLoading(false); });

--- a/frontend/src/components/dashboard/AssetDetailSidebar.jsx
+++ b/frontend/src/components/dashboard/AssetDetailSidebar.jsx
@@ -214,7 +214,7 @@ export function AssetDetailSidebar({ asset, isOpen, onClose, onFavoriteToggle })
               </p>
             ) : dayChangePct != null && (
               <p className={cn('text-sm font-mono tabular-nums', changeColor)}>
-                {getChangeIndicator(dayChangePct)} ({formatPercent(dayChangePct)}) today
+                {getChangeIndicator(dayChangePct)} {formatPercent(dayChangePct)}
               </p>
             )}
           </div>

--- a/frontend/src/hooks/useAssetsData.js
+++ b/frontend/src/hooks/useAssetsData.js
@@ -30,13 +30,13 @@ export function useAssetsData() {
       try {
         const [assetsData, positionsData] = await Promise.all([
           fetchJson(`/assets/market?display_currency=${currency}&limit=500`, 'assets'),
-          fetchJson(`/positions?display_currency=${currency}&limit=500${portfolioParam}`, 'positions'),
+          fetchJson(`/positions?display_currency=${currency}&limit=500${portfolioParam}`, 'positions').catch(() => null),
         ]);
 
         if (cancelled) return;
 
         setAssets(assetsData.items);
-        setPositionMap(new Map(positionsData.items.map((pos) => [pos.asset_id, pos])));
+        setPositionMap(new Map(positionsData ? positionsData.items.map((pos) => [pos.asset_id, pos]) : []));
       } catch (err) {
         if (!cancelled) setError(err.message);
       } finally {

--- a/frontend/src/hooks/useAssetsData.js
+++ b/frontend/src/hooks/useAssetsData.js
@@ -1,0 +1,73 @@
+import { useState, useEffect, useCallback } from 'react';
+import { useCurrency, usePortfolio } from '../contexts';
+import api from '../lib/api';
+
+async function fetchJson(endpoint, label) {
+  const res = await api(endpoint);
+  if (!res.ok) throw new Error(`Failed to fetch ${label}: ${res.statusText}`);
+  return res.json();
+}
+
+export function useAssetsData() {
+  const { currency: globalCurrency } = useCurrency();
+  const { selectedPortfolioId, portfolioCurrency } = usePortfolio();
+  const currency = portfolioCurrency || globalCurrency;
+
+  const [assets, setAssets] = useState([]);
+  const [positionMap, setPositionMap] = useState(new Map());
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function fetchAll() {
+      setLoading(true);
+      setError(null);
+
+      const portfolioParam = selectedPortfolioId ? `&portfolio_id=${selectedPortfolioId}` : '';
+
+      try {
+        const [assetsData, positionsData] = await Promise.all([
+          fetchJson(`/assets/market?display_currency=${currency}&limit=500`, 'assets'),
+          fetchJson(`/positions?display_currency=${currency}&limit=500${portfolioParam}`, 'positions'),
+        ]);
+
+        if (cancelled) return;
+
+        setAssets(assetsData.items);
+        setPositionMap(new Map(positionsData.items.map((pos) => [pos.asset_id, pos])));
+      } catch (err) {
+        if (!cancelled) setError(err.message);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+
+    fetchAll();
+    return () => { cancelled = true; };
+  }, [currency, selectedPortfolioId]);
+
+  const toggleFavorite = useCallback(async (assetId) => {
+    setAssets((prev) =>
+      prev.map((a) => (a.id === assetId ? { ...a, is_favorite: !a.is_favorite } : a))
+    );
+    try {
+      await api(`/assets/${assetId}/favorite`, { method: 'PUT' });
+    } catch {
+      setAssets((prev) =>
+        prev.map((a) => (a.id === assetId ? { ...a, is_favorite: !a.is_favorite } : a))
+      );
+    }
+  }, []);
+
+  // Sync local state only (no API call) -- used when AssetDetailSidebar
+  // already fires its own PUT /assets/:id/favorite
+  const syncFavorite = useCallback((assetId, newValue) => {
+    setAssets((prev) =>
+      prev.map((a) => (a.id === assetId ? { ...a, is_favorite: newValue } : a))
+    );
+  }, []);
+
+  return { assets, positionMap, loading, error, currency, toggleFavorite, syncFavorite };
+}

--- a/frontend/src/pages/Assets.jsx
+++ b/frontend/src/pages/Assets.jsx
@@ -1,877 +1,183 @@
-/**
- * Assets Page - Finch Redesign
- *
- * Purpose: Browse all assets with market data, performance metrics, and favorites
- * Design Reference: Delta by eToro
- */
-
-import React, { useState, useEffect, useMemo } from 'react';
-import { useNavigate } from 'react-router-dom';
-import { cn, formatCurrency, api } from '../lib';
-import { useCurrency, usePortfolio } from '../contexts';
+import { useState, useMemo, useEffect } from 'react';
+import { useAssetsData } from '../hooks/useAssetsData';
 import { PageContainer } from '../components/layout';
 import { Skeleton } from '../components/ui';
+import { AssetClassTabs, AssetsFilterRow, AssetsTable, PERIOD_KEYS } from '../components/assets';
+import { AssetDetailSidebar } from '../components/dashboard';
 
-// ============================================
-// CONSTANTS
-// ============================================
-
-const ASSET_CLASSES = ['All', 'Crypto', 'Stock', 'ETF', 'MutualFund', 'Cash', 'Other'];
-const ASSET_CLASS_LABELS = {
-  All: 'All',
-  Crypto: 'Crypto',
-  Stock: 'Stocks',
-  ETF: 'ETFs',
-  MutualFund: 'Funds',
-  Cash: 'Forex',
-  Other: 'Other',
-};
-
-const TIME_PERIODS = [
-  { id: '1d', label: '1D', changeKey: 'change_1d', pctKey: 'change_1d_pct' },
-  { id: '1w', label: '1W', changeKey: 'change_1w', pctKey: 'change_1w_pct' },
-  { id: '1m', label: '1M', changeKey: 'change_1m', pctKey: 'change_1m_pct' },
-];
-
-// ============================================
-// ICONS
-// ============================================
-
-function MagnifyingGlassIcon({ className }) {
-  return (
-    <svg className={className} fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
-      <path strokeLinecap="round" strokeLinejoin="round" d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z" />
-    </svg>
-  );
-}
-
-function StarIcon({ className, filled }) {
-  if (filled) {
-    return (
-      <svg className={className} viewBox="0 0 24 24" fill="currentColor">
-        <path fillRule="evenodd" d="M10.788 3.21c.448-1.077 1.976-1.077 2.424 0l2.082 5.006 5.404.434c1.164.093 1.636 1.545.749 2.305l-4.117 3.527 1.257 5.273c.271 1.136-.964 2.033-1.96 1.425L12 18.354 7.373 21.18c-.996.608-2.231-.29-1.96-1.425l1.257-5.273-4.117-3.527c-.887-.76-.415-2.212.749-2.305l5.404-.434 2.082-5.005Z" clipRule="evenodd" />
-      </svg>
-    );
+function getSortValue(asset, sortKey, periodKeys, positionMap) {
+  switch (sortKey) {
+    case 'symbol': return asset.symbol?.toLowerCase() || '';
+    case 'price': return asset.last_fetched_price ?? -Infinity;
+    case 'changePct': return asset[periodKeys.pct] ?? -Infinity;
+    case 'marketCap': return positionMap.get(asset.id)?.market_cap ?? -Infinity;
+    case 'volume': return -Infinity;
+    default: return 0;
   }
-  return (
-    <svg className={className} fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
-      <path strokeLinecap="round" strokeLinejoin="round" d="M11.48 3.499a.562.562 0 0 1 1.04 0l2.125 5.111a.563.563 0 0 0 .475.345l5.518.442c.499.04.701.663.321.988l-4.204 3.602a.563.563 0 0 0-.182.557l1.285 5.385a.562.562 0 0 1-.84.61l-4.725-2.885a.562.562 0 0 0-.586 0L6.982 20.54a.562.562 0 0 1-.84-.61l1.285-5.386a.562.562 0 0 0-.182-.557l-4.204-3.602a.562.562 0 0 1 .321-.988l5.518-.442a.563.563 0 0 0 .475-.345L11.48 3.5Z" />
-    </svg>
-  );
 }
-
-function ChevronUpIcon({ className }) {
-  return (
-    <svg className={className} fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
-      <path strokeLinecap="round" strokeLinejoin="round" d="m4.5 15.75 7.5-7.5 7.5 7.5" />
-    </svg>
-  );
-}
-
-function ChevronDownIcon({ className }) {
-  return (
-    <svg className={className} fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
-      <path strokeLinecap="round" strokeLinejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5" />
-    </svg>
-  );
-}
-
-function ChevronUpDownIcon({ className }) {
-  return (
-    <svg className={className} fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
-      <path strokeLinecap="round" strokeLinejoin="round" d="M8.25 15 12 18.75 15.75 15m-7.5-6L12 5.25 15.75 9" />
-    </svg>
-  );
-}
-
-function XMarkIcon({ className }) {
-  return (
-    <svg className={className} fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
-      <path strokeLinecap="round" strokeLinejoin="round" d="M6 18 18 6M6 6l12 12" />
-    </svg>
-  );
-}
-
-function ArrowTopRightIcon({ className }) {
-  return (
-    <svg className={className} fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
-      <path strokeLinecap="round" strokeLinejoin="round" d="m4.5 19.5 15-15m0 0H8.25m11.25 0v11.25" />
-    </svg>
-  );
-}
-
-function BriefcaseIcon({ className }) {
-  return (
-    <svg className={className} viewBox="0 0 20 20" fill="currentColor">
-      <path fillRule="evenodd" d="M6 3.75A2.75 2.75 0 0 1 8.75 1h2.5A2.75 2.75 0 0 1 14 3.75v.443c.572.055 1.14.122 1.706.2C17.053 4.582 18 5.75 18 7.07v3.469c0 1.126-.694 2.191-1.83 2.54-1.952.599-4.024.921-6.17.921s-4.219-.322-6.17-.921C2.694 12.73 2 11.665 2 10.539V7.07c0-1.321.947-2.489 2.294-2.676A41.047 41.047 0 0 1 6 4.193V3.75Zm6.5 0v.325a41.622 41.622 0 0 0-5 0V3.75c0-.69.56-1.25 1.25-1.25h2.5c.69 0 1.25.56 1.25 1.25ZM10 10a1 1 0 0 0-1 1v.01a1 1 0 0 0 1 1h.01a1 1 0 0 0 1-1V11a1 1 0 0 0-1-1H10Z" clipRule="evenodd" />
-      <path d="M3 15.055v-.684c.126.053.255.1.39.142 2.092.642 4.313.987 6.61.987 2.297 0 4.518-.345 6.61-.987.135-.041.264-.089.39-.142v.684c0 1.347-.985 2.53-2.363 2.686a41.454 41.454 0 0 1-9.274 0C3.985 17.585 3 16.402 3 15.055Z" />
-    </svg>
-  );
-}
-
-// ============================================
-// HELPER FUNCTIONS
-// ============================================
-
-function formatPrice(value, currency) {
-  if (!value && value !== 0) return '—';
-  return formatCurrency(value, currency);
-}
-
-/**
- * Simple SVG line chart for price history
- */
-function SimpleLineChart({ data, height = 120, className }) {
-  if (!data || data.length === 0) {
-    return (
-      <div className={cn('flex items-center justify-center text-[var(--text-tertiary)] text-sm', className)} style={{ height }}>
-        No data available
-      </div>
-    );
-  }
-
-  const prices = data.map(d => d.close);
-  const minPrice = Math.min(...prices);
-  const maxPrice = Math.max(...prices);
-  const priceRange = maxPrice - minPrice || 1;
-
-  const padding = 4;
-  const chartHeight = height - padding * 2;
-
-  // Handle single data point - show horizontal line
-  if (prices.length === 1) {
-    const y = padding + chartHeight / 2;
-    const strokeColor = 'rgb(100, 116, 139)'; // slate-500 for neutral
-
-    return (
-      <div className={className} style={{ height }}>
-        <svg width="100%" height={height} viewBox={`0 0 100 ${height}`} preserveAspectRatio="none">
-          <line x1="0" y1={y} x2="100" y2={y} stroke={strokeColor} strokeWidth="1.5" vectorEffect="non-scaling-stroke" strokeDasharray="4 2" />
-        </svg>
-        <div className="text-center text-xs text-[var(--text-tertiary)] -mt-2">
-          Market closed · Last: {formatCurrency(prices[0], 'USD')}
-        </div>
-      </div>
-    );
-  }
-
-  // Generate path for multiple points
-  const points = prices.map((price, i) => {
-    const x = (i / (prices.length - 1)) * 100;
-    const y = padding + chartHeight - ((price - minPrice) / priceRange) * chartHeight;
-    return `${x},${y}`;
-  });
-
-  const pathD = `M ${points.join(' L ')}`;
-
-  // Determine if price went up or down
-  const startPrice = prices[0];
-  const endPrice = prices[prices.length - 1];
-  const isPositive = endPrice >= startPrice;
-  const strokeColor = isPositive ? 'rgb(16, 185, 129)' : 'rgb(239, 68, 68)'; // emerald-500 / red-500
-  const fillColor = isPositive ? 'rgba(16, 185, 129, 0.1)' : 'rgba(239, 68, 68, 0.1)';
-
-  // Create area path (closed path for fill)
-  const areaPath = `${pathD} L 100,${height - padding} L 0,${height - padding} Z`;
-
-  return (
-    <div className={className} style={{ height }}>
-      <svg width="100%" height={height} viewBox={`0 0 100 ${height}`} preserveAspectRatio="none">
-        {/* Area fill */}
-        <path d={areaPath} fill={fillColor} />
-        {/* Line */}
-        <path d={pathD} fill="none" stroke={strokeColor} strokeWidth="1.5" vectorEffect="non-scaling-stroke" />
-      </svg>
-    </div>
-  );
-}
-
-// ============================================
-// COMPONENTS
-// ============================================
-
-function ChangeIndicator({ value, size = 'normal' }) {
-  if (value === null || value === undefined) {
-    return <span className="text-[var(--text-tertiary)]">—</span>;
-  }
-
-  const isPositive = value >= 0;
-  const Icon = isPositive ? ChevronUpIcon : ChevronDownIcon;
-
-  return (
-    <span
-      className={cn(
-        'inline-flex items-center font-mono tabular-nums',
-        size === 'large' ? 'text-lg font-semibold gap-1' : 'text-sm font-medium gap-0.5',
-        isPositive ? 'text-emerald-600 dark:text-emerald-400' : 'text-red-600 dark:text-red-400'
-      )}
-    >
-      <Icon className={size === 'large' ? 'w-5 h-5' : 'w-3.5 h-3.5'} />
-      {isPositive ? '+' : ''}{value.toFixed(2)}%
-    </span>
-  );
-}
-
-function SortableHeader({ label, sortKey, currentSort, onSort, align = 'left' }) {
-  const isActive = currentSort.key === sortKey;
-
-  return (
-    <button
-      onClick={() => onSort(sortKey)}
-      className={cn(
-        'flex items-center gap-1 font-medium text-sm transition-colors cursor-pointer',
-        align === 'right' && 'justify-end w-full',
-        isActive ? 'text-[var(--text-primary)]' : 'text-[var(--text-secondary)] hover:text-[var(--text-primary)]'
-      )}
-    >
-      {label}
-      <ChevronUpDownIcon className={cn('w-4 h-4', isActive && 'text-accent')} />
-    </button>
-  );
-}
-
-function AssetRow({ asset, currency, userHolding, timePeriod, onToggleFavorite, onClick }) {
-  const changeValue = asset[timePeriod.changeKey];
-  const changePct = asset[timePeriod.pctKey];
-
-  return (
-    <tr
-      onClick={() => onClick(asset)}
-      className="hover:bg-[var(--bg-tertiary)] transition-colors cursor-pointer"
-    >
-      {/* Favorite */}
-      <td className="px-4 py-4">
-        <button
-          onClick={(e) => {
-            e.stopPropagation();
-            onToggleFavorite(asset.id);
-          }}
-          className="p-1 rounded hover:bg-[var(--bg-secondary)] transition-colors cursor-pointer"
-        >
-          <StarIcon
-            className={cn(
-              'w-5 h-5',
-              asset.is_favorite
-                ? 'text-amber-500'
-                : 'text-[var(--text-tertiary)] hover:text-amber-500'
-            )}
-            filled={asset.is_favorite}
-          />
-        </button>
-      </td>
-
-      {/* Asset */}
-      <td className="px-4 py-4">
-        <div className="flex items-center gap-3">
-          <div>
-            <div className="flex items-center gap-2">
-              <p className="font-semibold text-[var(--text-primary)]">{asset.symbol}</p>
-              {userHolding && (
-                <span className="flex items-center justify-center w-5 h-5 rounded-full bg-accent/15" title="In your portfolio">
-                  <BriefcaseIcon className="w-3 h-3 text-accent" />
-                </span>
-              )}
-            </div>
-            <p className="text-sm text-[var(--text-secondary)]">{asset.name}</p>
-          </div>
-        </div>
-      </td>
-
-      {/* Price - show in native currency */}
-      <td className="px-4 py-4 text-right">
-        <p className="font-mono tabular-nums text-[var(--text-primary)]">
-          {formatPrice(asset.last_fetched_price, asset.currency)}
-        </p>
-      </td>
-
-      {/* Change */}
-      <td className="px-4 py-4 text-right">
-        <div className="flex flex-col items-end">
-          <ChangeIndicator value={changePct} />
-          {changeValue !== null && changeValue !== undefined && (
-            <span className={cn(
-              'text-xs font-mono tabular-nums',
-              changeValue >= 0 ? 'text-emerald-600 dark:text-emerald-400' : 'text-red-600 dark:text-red-400'
-            )}>
-              {changeValue >= 0 ? '+' : ''}{formatCurrency(changeValue, currency)}
-            </span>
-          )}
-        </div>
-      </td>
-
-      {/* Sector/Category */}
-      <td className="px-4 py-4 text-right">
-        <p className="text-sm text-[var(--text-secondary)]">
-          {asset.category || asset.industry || '—'}
-        </p>
-      </td>
-    </tr>
-  );
-}
-
-function AssetDetailSlideOut({ asset, currency, userHolding, onClose, onToggleFavorite }) {
-  const navigate = useNavigate();
-  const [chartPeriod, setChartPeriod] = useState('1mo');
-  const [historicalData, setHistoricalData] = useState(null);
-  const [loadingHistory, setLoadingHistory] = useState(false);
-
-  useEffect(() => {
-    if (asset?.symbol) {
-      setLoadingHistory(true);
-      api(`/prices/historical/${asset.symbol}?period=${chartPeriod}`)
-        .then((res) => res.ok ? res.json() : null)
-        .then((data) => setHistoricalData(data))
-        .catch(() => setHistoricalData(null))
-        .finally(() => setLoadingHistory(false));
-    }
-  }, [asset?.symbol, chartPeriod]);
-
-  if (!asset) return null;
-
-  return (
-    <>
-      {/* Backdrop */}
-      <div
-        className="fixed inset-0 bg-black/30 z-40"
-        onClick={onClose}
-      />
-
-      {/* Slide-out Panel */}
-      <div className="fixed right-0 top-0 h-full w-full max-w-md bg-[var(--bg-primary)] shadow-2xl z-50 overflow-y-auto">
-        {/* Header */}
-        <div className="sticky top-0 bg-[var(--bg-primary)] border-b border-[var(--border-primary)] p-4 flex items-center justify-between">
-          <div className="flex items-center gap-3">
-            <button
-              onClick={() => onToggleFavorite(asset.id)}
-              className="p-2 rounded-lg hover:bg-[var(--bg-tertiary)] transition-colors cursor-pointer"
-            >
-              <StarIcon
-                className={cn(
-                  'w-5 h-5',
-                  asset.is_favorite ? 'text-amber-500' : 'text-[var(--text-tertiary)]'
-                )}
-                filled={asset.is_favorite}
-              />
-            </button>
-          </div>
-          <div className="flex items-center gap-2">
-            <button
-              onClick={() => navigate(`/assets/${asset.id}`)}
-              className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm font-medium bg-accent text-white hover:bg-accent/90 transition-colors"
-            >
-              View Details
-              <ArrowTopRightIcon className="w-3.5 h-3.5" />
-            </button>
-            <button
-              onClick={onClose}
-              className="p-2 rounded-lg hover:bg-[var(--bg-tertiary)] transition-colors cursor-pointer"
-            >
-              <XMarkIcon className="w-5 h-5 text-[var(--text-secondary)]" />
-            </button>
-          </div>
-        </div>
-
-        {/* Content */}
-        <div className="p-6 space-y-6">
-          {/* Asset Header */}
-          <div>
-            <h2
-              className="text-xl font-semibold text-[var(--text-primary)] hover:text-accent cursor-pointer transition-colors"
-              onClick={() => navigate(`/assets/${asset.id}`)}
-            >{asset.name}</h2>
-            <p className="text-sm text-[var(--text-secondary)]">
-              {asset.symbol} · {asset.asset_class} · {asset.category || asset.industry || 'N/A'}
-            </p>
-          </div>
-
-          {/* Price - show in native currency */}
-          <div>
-            <p className="text-3xl font-semibold font-mono tabular-nums text-[var(--text-primary)]">
-              {formatPrice(asset.last_fetched_price, asset.currency)}
-            </p>
-            {asset.last_fetched_at && (
-              <p className="text-sm text-[var(--text-tertiary)] mt-1">
-                Last updated: {new Date(asset.last_fetched_at).toLocaleString()}
-              </p>
-            )}
-          </div>
-
-          {/* Price Chart */}
-          <div className="bg-[var(--bg-secondary)] rounded-xl border border-[var(--border-primary)] p-4">
-            <div className="flex items-center justify-between mb-4">
-              <h3 className="text-sm font-medium text-[var(--text-primary)]">Price History</h3>
-              <div className="flex gap-1">
-                {[
-                  { id: '1d', label: '1D' },
-                  { id: '5d', label: '5D' },
-                  { id: '1mo', label: '1M' },
-                  { id: '3mo', label: '3M' },
-                  { id: '1y', label: '1Y' },
-                ].map((period) => (
-                  <button
-                    key={period.id}
-                    onClick={() => setChartPeriod(period.id)}
-                    className={cn(
-                      'px-2 py-1 text-xs font-medium rounded transition-colors cursor-pointer',
-                      chartPeriod === period.id
-                        ? 'bg-accent text-white'
-                        : 'text-[var(--text-secondary)] hover:bg-[var(--bg-tertiary)]'
-                    )}
-                  >
-                    {period.label}
-                  </button>
-                ))}
-              </div>
-            </div>
-            {/* Price Chart */}
-            <div className="h-32">
-              {loadingHistory ? (
-                <div className="h-full flex items-center justify-center text-[var(--text-tertiary)] text-sm">
-                  Loading chart...
-                </div>
-              ) : historicalData?.data ? (
-                <SimpleLineChart data={historicalData.data} height={128} />
-              ) : (
-                <div className="h-full flex items-center justify-center text-[var(--text-tertiary)] text-sm">
-                  No historical data available
-                </div>
-              )}
-            </div>
-          </div>
-
-          {/* Asset Details */}
-          <div className="bg-[var(--bg-secondary)] rounded-xl border border-[var(--border-primary)] p-4">
-            <h3 className="text-sm font-medium text-[var(--text-primary)] mb-4">Asset Details</h3>
-            <div className="space-y-3">
-              <div className="flex justify-between">
-                <span className="text-sm text-[var(--text-secondary)]">Asset Class</span>
-                <span className="text-sm text-[var(--text-primary)]">
-                  {ASSET_CLASS_LABELS[asset.asset_class] || asset.asset_class}
-                </span>
-              </div>
-              {asset.category && (
-                <div className="flex justify-between">
-                  <span className="text-sm text-[var(--text-secondary)]">Category</span>
-                  <span className="text-sm text-[var(--text-primary)]">{asset.category}</span>
-                </div>
-              )}
-              {asset.industry && (
-                <div className="flex justify-between">
-                  <span className="text-sm text-[var(--text-secondary)]">Industry</span>
-                  <span className="text-sm text-[var(--text-primary)]">{asset.industry}</span>
-                </div>
-              )}
-              <div className="flex justify-between">
-                <span className="text-sm text-[var(--text-secondary)]">Currency</span>
-                <span className="text-sm text-[var(--text-primary)]">{asset.currency}</span>
-              </div>
-              {asset.data_source && (
-                <div className="flex justify-between">
-                  <span className="text-sm text-[var(--text-secondary)]">Data Source</span>
-                  <span className="text-sm text-[var(--text-primary)]">{asset.data_source}</span>
-                </div>
-              )}
-            </div>
-          </div>
-
-          {/* User Holdings */}
-          <div className="bg-[var(--bg-secondary)] rounded-xl border border-[var(--border-primary)] p-4">
-            <h3 className="text-sm font-medium text-[var(--text-primary)] mb-3">Your Holdings</h3>
-            {userHolding ? (
-              <div className="space-y-3">
-                <div className="flex justify-between">
-                  <span className="text-sm text-[var(--text-secondary)]">Quantity</span>
-                  <span className="text-sm font-mono tabular-nums text-[var(--text-primary)]">
-                    {userHolding.total_quantity}
-                  </span>
-                </div>
-                <div className="flex justify-between">
-                  <span className="text-sm text-[var(--text-secondary)]">Market Value</span>
-                  <span className="text-sm font-mono tabular-nums text-[var(--text-primary)]">
-                    {formatCurrency(userHolding.total_market_value, currency)}
-                  </span>
-                </div>
-                <div className="flex justify-between">
-                  <span className="text-sm text-[var(--text-secondary)]">Cost Basis</span>
-                  <span className="text-sm font-mono tabular-nums text-[var(--text-primary)]">
-                    {formatCurrency(userHolding.total_cost_basis, currency)}
-                  </span>
-                </div>
-                <button
-                  onClick={() => navigate('/holdings')}
-                  className="w-full mt-2 flex items-center justify-center gap-2 px-4 py-2 rounded-lg text-sm font-medium bg-accent text-white hover:bg-accent/90 transition-colors cursor-pointer"
-                >
-                  View in Holdings
-                  <ArrowTopRightIcon className="w-4 h-4" />
-                </button>
-              </div>
-            ) : (
-              <p className="text-sm text-[var(--text-tertiary)]">
-                You don't hold this asset
-              </p>
-            )}
-          </div>
-        </div>
-
-
-      </div>
-    </>
-  );
-}
-
-function TableSkeleton() {
-  return (
-    <div className="bg-[var(--bg-secondary)] rounded-xl border border-[var(--border-primary)] overflow-hidden">
-      <div className="p-4 space-y-4">
-        {[...Array(8)].map((_, i) => (
-          <div key={i} className="flex items-center gap-4">
-            <Skeleton className="w-8 h-8 rounded" />
-            <div className="flex-1 space-y-2">
-              <Skeleton className="h-4 w-24" />
-              <Skeleton className="h-3 w-40" />
-            </div>
-            <Skeleton className="h-4 w-16" />
-            <Skeleton className="h-4 w-20" />
-          </div>
-        ))}
-      </div>
-    </div>
-  );
-}
-
-function EmptyState({ searchQuery }) {
-  return (
-    <div className="text-center py-16">
-      <div className="inline-flex p-4 rounded-full bg-[var(--bg-tertiary)] mb-4">
-        <MagnifyingGlassIcon className="w-8 h-8 text-[var(--text-tertiary)]" />
-      </div>
-      <h3 className="text-lg font-semibold text-[var(--text-primary)]">No assets found</h3>
-      <p className="text-[var(--text-secondary)] mt-1">
-        {searchQuery
-          ? `No assets matching "${searchQuery}"`
-          : 'No assets available'}
-      </p>
-    </div>
-  );
-}
-
-// ============================================
-// MAIN COMPONENT
-// ============================================
 
 export default function Assets() {
-  const { currency } = useCurrency();
-  const { selectedPortfolioId } = usePortfolio();
+  const { assets, positionMap, loading, error, currency, toggleFavorite, syncFavorite } = useAssetsData();
+
+  const [activeTab, setActiveTab] = useState('All');
   const [searchQuery, setSearchQuery] = useState('');
-  const [selectedClass, setSelectedClass] = useState('All');
+  const [selectedPeriod, setSelectedPeriod] = useState('1d');
   const [showFavoritesOnly, setShowFavoritesOnly] = useState(false);
-  const [timePeriod, setTimePeriod] = useState(TIME_PERIODS[0]); // Default to 1D
-  const [sort, setSort] = useState({ key: 'symbol', direction: 'asc' });
-  const [selectedAsset, setSelectedAsset] = useState(null);
+  const [sortConfig, setSortConfig] = useState({ key: 'symbol', direction: 'asc' });
+  const [sidebarAsset, setSidebarAsset] = useState(null);
 
-  // Data states
-  const [assets, setAssets] = useState([]);
-  const [positions, setPositions] = useState([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(null);
-
-  // Fetch assets with price changes
   useEffect(() => {
-    const fetchData = async () => {
-      setLoading(true);
-      setError(null);
-
-      try {
-        const portfolioParam = selectedPortfolioId ? `&portfolio_id=${selectedPortfolioId}` : '';
-        const [assetsRes, positionsRes] = await Promise.all([
-          api(`/assets/market?limit=500&display_currency=${currency}`),
-          api(`/positions?display_currency=${currency}${portfolioParam}`),
-        ]);
-
-        if (!assetsRes.ok) throw new Error('Failed to fetch assets');
-
-        const assetsData = await assetsRes.json();
-        setAssets(assetsData.items);
-
-        if (positionsRes.ok) {
-          const positionsData = await positionsRes.json();
-          setPositions(positionsData.items);
-        }
-      } catch (err) {
-        setError(err.message);
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    fetchData();
-  }, [currency, selectedPortfolioId]);
-
-  // Create a map of asset_id -> position for quick lookup
-  const positionsMap = useMemo(() => {
-    const map = {};
-    positions.forEach((pos) => {
-      map[pos.asset_id] = pos;
-    });
-    return map;
-  }, [positions]);
-
-  // Filter assets
-  const filteredAssets = useMemo(() => {
-    return assets.filter((asset) => {
-      const matchesSearch =
-        asset.symbol.toLowerCase().includes(searchQuery.toLowerCase()) ||
-        asset.name.toLowerCase().includes(searchQuery.toLowerCase());
-      const matchesClass = selectedClass === 'All' || asset.asset_class === selectedClass;
-      const matchesFavorite = !showFavoritesOnly || asset.is_favorite;
-      return matchesSearch && matchesClass && matchesFavorite;
-    });
-  }, [assets, searchQuery, selectedClass, showFavoritesOnly]);
-
-  // Sort assets
-  const sortedAssets = useMemo(() => {
-    return [...filteredAssets].sort((a, b) => {
-      let aVal = a[sort.key];
-      let bVal = b[sort.key];
-
-      // Handle null values
-      if (aVal === null || aVal === undefined) aVal = sort.direction === 'asc' ? Infinity : -Infinity;
-      if (bVal === null || bVal === undefined) bVal = sort.direction === 'asc' ? Infinity : -Infinity;
-
-      if (typeof aVal === 'string') {
-        aVal = aVal.toLowerCase();
-        bVal = bVal.toLowerCase();
-      }
-
-      if (sort.direction === 'asc') {
-        return aVal < bVal ? -1 : aVal > bVal ? 1 : 0;
-      } else {
-        return aVal > bVal ? -1 : aVal < bVal ? 1 : 0;
-      }
-    });
-  }, [filteredAssets, sort]);
+    setSearchQuery('');
+    setShowFavoritesOnly(false);
+  }, [activeTab]);
 
   const handleSort = (key) => {
-    setSort((prev) => ({
+    setSortConfig((prev) => ({
       key,
       direction: prev.key === key && prev.direction === 'asc' ? 'desc' : 'asc',
     }));
   };
 
-  const handleToggleFavorite = async (assetId) => {
-    try {
-      const res = await api(`/assets/${assetId}/favorite`, {
-        method: 'PUT',
-      });
-
-      if (res.ok) {
-        const updatedAsset = await res.json();
-        setAssets((prev) =>
-          prev.map((asset) =>
-            asset.id === assetId ? { ...asset, is_favorite: updatedAsset.is_favorite } : asset
-          )
-        );
-        // Update selected asset if open
-        if (selectedAsset?.id === assetId) {
-          setSelectedAsset((prev) =>
-            prev ? { ...prev, is_favorite: updatedAsset.is_favorite } : null
-          );
-        }
-      }
-    } catch (err) {
-      console.error('Failed to toggle favorite:', err);
-    }
+  const handleRowClick = (asset) => {
+    setSidebarAsset({
+      id: asset.id,
+      symbol: asset.symbol,
+      name: asset.name,
+      asset_class: asset.asset_class,
+      current_price: asset.last_fetched_price,
+      day_change_pct: asset.change_1d_pct,
+      currency: asset.currency,
+    });
   };
 
-  const favoriteCount = assets.filter((a) => a.is_favorite).length;
+  const { filteredAssets, totalCount, favoritesCount } = useMemo(() => {
+    const periodKeys = PERIOD_KEYS[selectedPeriod] || PERIOD_KEYS['1d'];
+    const query = searchQuery.toLowerCase();
 
-  // Count assets per class for badges
-  const classCounts = useMemo(() => {
-    return ASSET_CLASSES.reduce((acc, cls) => {
-      acc[cls] = cls === 'All'
-        ? assets.length
-        : assets.filter((a) => a.asset_class === cls).length;
-      return acc;
-    }, {});
-  }, [assets]);
+    // Single pass to compute tab count, favorites count, and filtered list
+    const filtered = [];
+    let tabCount = 0;
+    let favCount = 0;
+    for (const a of assets) {
+      const inTab = activeTab === 'All' || a.asset_class === activeTab;
+      if (inTab) tabCount++;
+      if (a.is_favorite) favCount++;
 
-  // Filter out classes with 0 assets (except "All")
-  const visibleClasses = ASSET_CLASSES.filter((cls) => cls === 'All' || classCounts[cls] > 0);
+      if (!inTab) continue;
+      if (showFavoritesOnly && !a.is_favorite) continue;
+      if (query) {
+        const matchSymbol = a.symbol?.toLowerCase().includes(query);
+        const matchName = a.name?.toLowerCase().includes(query);
+        if (!matchSymbol && !matchName) continue;
+      }
+      filtered.push(a);
+    }
+
+    const sorted = [...filtered].sort((a, b) => {
+      const va = getSortValue(a, sortConfig.key, periodKeys, positionMap);
+      const vb = getSortValue(b, sortConfig.key, periodKeys, positionMap);
+      if (typeof va === 'string') {
+        return sortConfig.direction === 'asc' ? va.localeCompare(vb) : vb.localeCompare(va);
+      }
+      return sortConfig.direction === 'asc' ? va - vb : vb - va;
+    });
+
+    return { filteredAssets: sorted, totalCount: tabCount, favoritesCount: favCount };
+  }, [assets, activeTab, searchQuery, selectedPeriod, showFavoritesOnly, sortConfig, positionMap]);
 
   if (loading) {
     return (
-      <PageContainer>
-        <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4 mb-6">
-          <div>
-            <Skeleton className="h-8 w-32 mb-2" />
-            <Skeleton className="h-4 w-48" />
-          </div>
-          <Skeleton className="h-10 w-64" />
+      <PageContainer className="mx-0 max-w-none">
+        <div className="mb-5">
+          <Skeleton className="h-7 w-24 mb-1" />
+          <Skeleton className="h-4 w-32" />
         </div>
-        <Skeleton className="h-12 w-full mb-4" />
-        <TableSkeleton />
+        <Skeleton className="h-10 w-full mb-4 rounded-[10px]" />
+        <div className="flex items-center gap-2.5 mb-4">
+          <Skeleton className="h-9 w-[240px]" />
+          <div className="flex-1" />
+          <Skeleton className="h-9 w-32" />
+          <Skeleton className="h-9 w-28" />
+        </div>
+        <AssetsTable
+          assets={[]}
+          positionMap={new Map()}
+          period="1d"
+          currency={currency}
+          sortConfig={sortConfig}
+          onSort={() => {}}
+          onRowClick={() => {}}
+          onToggleFavorite={() => {}}
+          loading={true}
+          totalCount={0}
+          favoritesCount={0}
+        />
       </PageContainer>
     );
   }
 
   if (error) {
     return (
-      <PageContainer>
-        <div className="text-center py-16">
-          <h3 className="text-lg font-semibold text-[var(--text-primary)]">Error loading assets</h3>
-          <p className="text-[var(--text-secondary)] mt-1">{error}</p>
+      <PageContainer className="mx-0 max-w-none">
+        <h1 className="text-[22px] font-bold tracking-[-0.3px] text-[var(--text-primary)] mb-5">Assets</h1>
+        <div className="text-center py-12">
+          <p className="text-[var(--negative)] mb-2">Error loading assets</p>
+          <p className="text-[var(--text-secondary)] text-sm">{error}</p>
+          <button
+            onClick={() => window.location.reload()}
+            className="mt-4 px-4 py-2 bg-[var(--accent-primary)] text-white rounded-lg hover:opacity-90 transition-colors cursor-pointer"
+          >
+            Retry
+          </button>
         </div>
       </PageContainer>
     );
   }
 
   return (
-    <PageContainer>
-      {/* Header */}
-      <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4 mb-6">
-        <div>
-          <h1 className="text-2xl font-semibold text-[var(--text-primary)]">Assets</h1>
-          <p className="text-[var(--text-secondary)] mt-1">
-            {filteredAssets.length} of {assets.length} assets · {favoriteCount} favorites
-          </p>
-        </div>
-
-        {/* Search */}
-        <div className="relative w-full sm:w-64">
-          <MagnifyingGlassIcon className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-[var(--text-tertiary)]" />
-          <input
-            type="text"
-            placeholder="Search assets..."
-            value={searchQuery}
-            onChange={(e) => setSearchQuery(e.target.value)}
-            className={cn(
-              'w-full pl-9 pr-4 py-2 rounded-lg text-sm',
-              'bg-[var(--bg-secondary)] border border-[var(--border-primary)]',
-              'text-[var(--text-primary)] placeholder:text-[var(--text-tertiary)]',
-              'focus:outline-none focus:ring-2 focus:ring-accent/50 focus:border-accent'
-            )}
-          />
-        </div>
+    <PageContainer className="mx-0 max-w-none">
+      <div className="mb-5">
+        <h1 className="text-[22px] font-bold tracking-[-0.3px] text-[var(--text-primary)]">Assets</h1>
+        <p className="text-[13px] text-[var(--text-tertiary)] mt-0.5">
+          {filteredAssets.length} asset{filteredAssets.length !== 1 ? 's' : ''}
+        </p>
       </div>
 
-      {/* Asset Class Tabs */}
-      <div className="flex items-center gap-1 p-1 bg-[var(--bg-tertiary)] rounded-lg mb-4 overflow-x-auto">
-        {visibleClasses.map((cls) => (
-          <button
-            key={cls}
-            onClick={() => setSelectedClass(cls)}
-            className={cn(
-              'flex items-center gap-2 px-4 py-2 rounded-md text-sm font-medium transition-colors cursor-pointer whitespace-nowrap',
-              selectedClass === cls
-                ? 'bg-[var(--bg-primary)] text-[var(--text-primary)] shadow-sm'
-                : 'text-[var(--text-secondary)] hover:text-[var(--text-primary)]'
-            )}
-          >
-            {ASSET_CLASS_LABELS[cls] || cls}
-            <span className={cn(
-              'text-xs px-1.5 py-0.5 rounded-full',
-              selectedClass === cls
-                ? 'bg-accent/10 text-accent'
-                : 'bg-[var(--bg-secondary)] text-[var(--text-tertiary)]'
-            )}>
-              {classCounts[cls]}
-            </span>
-          </button>
-        ))}
-      </div>
+      <AssetClassTabs
+        assets={assets}
+        activeTab={activeTab}
+        onTabChange={setActiveTab}
+      />
 
-      {/* Filter Row */}
-      <div className="flex flex-wrap items-center gap-3 mb-6">
-        {/* Time Period */}
-        <div className="flex items-center gap-1 p-1 bg-[var(--bg-secondary)] border border-[var(--border-primary)] rounded-lg">
-          {TIME_PERIODS.map((period) => (
-            <button
-              key={period.id}
-              onClick={() => setTimePeriod(period)}
-              className={cn(
-                'px-3 py-1.5 rounded-md text-xs font-medium transition-colors cursor-pointer',
-                timePeriod.id === period.id
-                  ? 'bg-accent text-white'
-                  : 'text-[var(--text-secondary)] hover:text-[var(--text-primary)]'
-              )}
-            >
-              {period.label}
-            </button>
-          ))}
-        </div>
+      <AssetsFilterRow
+        searchQuery={searchQuery}
+        onSearchChange={setSearchQuery}
+        selectedPeriod={selectedPeriod}
+        onPeriodChange={setSelectedPeriod}
+        showFavoritesOnly={showFavoritesOnly}
+        onFavoritesToggle={() => setShowFavoritesOnly((v) => !v)}
+      />
 
-        {/* Favorites Toggle */}
-        <button
-          onClick={() => setShowFavoritesOnly(!showFavoritesOnly)}
-          className={cn(
-            'flex items-center gap-2 px-3 py-2 rounded-lg text-sm font-medium transition-colors cursor-pointer',
-            showFavoritesOnly
-              ? 'bg-amber-100 text-amber-700 dark:bg-amber-950/40 dark:text-amber-400'
-              : 'bg-[var(--bg-secondary)] border border-[var(--border-primary)] text-[var(--text-secondary)] hover:text-[var(--text-primary)]'
-          )}
-        >
-          <StarIcon className="w-4 h-4" filled={showFavoritesOnly} />
-          Favorites Only
-        </button>
-      </div>
+      <AssetsTable
+        assets={filteredAssets}
+        positionMap={positionMap}
+        period={selectedPeriod}
+        currency={currency}
+        sortConfig={sortConfig}
+        onSort={handleSort}
+        onRowClick={handleRowClick}
+        onToggleFavorite={toggleFavorite}
+        loading={false}
+        totalCount={totalCount}
+        favoritesCount={favoritesCount}
+      />
 
-      {/* Table */}
-      {sortedAssets.length === 0 ? (
-        <EmptyState searchQuery={searchQuery} />
-      ) : (
-        <div className="bg-[var(--bg-secondary)] rounded-xl border border-[var(--border-primary)] overflow-hidden shadow-sm dark:shadow-none">
-          <div className="overflow-x-auto">
-            <table className="w-full table-fixed">
-              <thead>
-                <tr className="border-b border-[var(--border-primary)]">
-                  <th className="px-4 py-3 w-14"></th>
-                  <th className="px-4 py-3 text-left">
-                    <SortableHeader label="Asset" sortKey="symbol" currentSort={sort} onSort={handleSort} />
-                  </th>
-                  <th className="px-4 py-3 w-28 text-right">
-                    <SortableHeader label="Price" sortKey="last_fetched_price" currentSort={sort} onSort={handleSort} align="right" />
-                  </th>
-                  <th className="px-4 py-3 w-36 text-right">
-                    <SortableHeader label={`Change (${timePeriod.label})`} sortKey={timePeriod.pctKey} currentSort={sort} onSort={handleSort} align="right" />
-                  </th>
-                  <th className="px-4 py-3 w-44 text-right">
-                    <SortableHeader label="Category" sortKey="category" currentSort={sort} onSort={handleSort} align="right" />
-                  </th>
-                </tr>
-              </thead>
-              <tbody>
-                {sortedAssets.map((asset) => (
-                  <AssetRow
-                    key={asset.id}
-                    asset={asset}
-                    currency={currency}
-                    userHolding={positionsMap[asset.id]}
-                    timePeriod={timePeriod}
-                    onToggleFavorite={handleToggleFavorite}
-                    onClick={setSelectedAsset}
-                  />
-                ))}
-              </tbody>
-            </table>
-          </div>
-
-          {/* Footer */}
-          <div className="px-4 py-3 border-t border-[var(--border-primary)] text-sm text-[var(--text-secondary)]">
-            Showing {sortedAssets.length} of {assets.length} assets
-          </div>
-        </div>
-      )}
-
-      {/* Asset Detail Slide-out */}
-      {selectedAsset && (
-        <AssetDetailSlideOut
-          asset={selectedAsset}
-          currency={currency}
-          userHolding={positionsMap[selectedAsset.id]}
-          onClose={() => setSelectedAsset(null)}
-          onToggleFavorite={handleToggleFavorite}
-        />
-      )}
+      <AssetDetailSidebar
+        asset={sidebarAsset}
+        isOpen={!!sidebarAsset}
+        onClose={() => setSidebarAsset(null)}
+        onFavoriteToggle={syncFavorite}
+      />
     </PageContainer>
   );
 }

--- a/frontend/src/pages/Assets.jsx
+++ b/frontend/src/pages/Assets.jsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useEffect, useCallback } from 'react';
+import { useState, useMemo, useEffect } from 'react';
 import { useAssetsData } from '../hooks/useAssetsData';
 import { PageContainer } from '../components/layout';
 import { Skeleton } from '../components/ui';
@@ -52,12 +52,12 @@ export default function Assets() {
     });
   };
 
-  const handleToggleFavorite = useCallback((assetId) => {
-    toggleFavorite(assetId);
-    setSidebarAsset((prev) =>
-      prev?.id === assetId ? { ...prev, is_favorite: !prev.is_favorite } : prev
-    );
-  }, [toggleFavorite]);
+  // Derive is_favorite from live assets so table toggles (and their reverts) propagate to the sidebar
+  const sidebarAssetLive = useMemo(() => {
+    if (!sidebarAsset) return null;
+    const live = assets.find((a) => a.id === sidebarAsset.id);
+    return live ? { ...sidebarAsset, is_favorite: live.is_favorite } : sidebarAsset;
+  }, [sidebarAsset, assets]);
 
   const { filteredAssets, totalCount, favoritesCount } = useMemo(() => {
     const periodKeys = PERIOD_KEYS[selectedPeriod] || PERIOD_KEYS['1d'];
@@ -175,14 +175,14 @@ export default function Assets() {
         sortConfig={sortConfig}
         onSort={handleSort}
         onRowClick={handleRowClick}
-        onToggleFavorite={handleToggleFavorite}
+        onToggleFavorite={toggleFavorite}
         loading={false}
         totalCount={totalCount}
         favoritesCount={favoritesCount}
       />
 
       <AssetDetailSidebar
-        asset={sidebarAsset}
+        asset={sidebarAssetLive}
         isOpen={!!sidebarAsset}
         onClose={() => setSidebarAsset(null)}
         onFavoriteToggle={syncFavorite}

--- a/frontend/src/pages/Assets.jsx
+++ b/frontend/src/pages/Assets.jsx
@@ -1,11 +1,11 @@
-import { useState, useMemo, useEffect } from 'react';
+import { useState, useMemo, useEffect, useCallback } from 'react';
 import { useAssetsData } from '../hooks/useAssetsData';
 import { PageContainer } from '../components/layout';
 import { Skeleton } from '../components/ui';
 import { AssetClassTabs, AssetsFilterRow, AssetsTable, PERIOD_KEYS } from '../components/assets';
 import { AssetDetailSidebar } from '../components/dashboard';
 
-function getSortValue(asset, sortKey, periodKeys, positionMap) {
+function getSortValue(asset, sortKey, periodKeys) {
   switch (sortKey) {
     case 'symbol': return asset.symbol?.toLowerCase() || '';
     case 'price': return asset.last_fetched_price ?? -Infinity;
@@ -39,17 +39,25 @@ export default function Assets() {
   };
 
   const handleRowClick = (asset) => {
+    const periodKeys = PERIOD_KEYS[selectedPeriod] || PERIOD_KEYS['1d'];
     setSidebarAsset({
       id: asset.id,
       symbol: asset.symbol,
       name: asset.name,
       asset_class: asset.asset_class,
       current_price: asset.last_fetched_price,
-      day_change_pct: asset.change_1d_pct,
+      day_change_pct: asset[periodKeys.pct],
       currency: asset.currency,
       is_favorite: asset.is_favorite,
     });
   };
+
+  const handleToggleFavorite = useCallback((assetId) => {
+    toggleFavorite(assetId);
+    setSidebarAsset((prev) =>
+      prev?.id === assetId ? { ...prev, is_favorite: !prev.is_favorite } : prev
+    );
+  }, [toggleFavorite]);
 
   const { filteredAssets, totalCount, favoritesCount } = useMemo(() => {
     const periodKeys = PERIOD_KEYS[selectedPeriod] || PERIOD_KEYS['1d'];
@@ -61,10 +69,7 @@ export default function Assets() {
     let favCount = 0;
     for (const a of assets) {
       const inTab = activeTab === 'All' || a.asset_class === activeTab;
-      if (inTab) {
-        tabCount++;
-        if (a.is_favorite) favCount++;
-      }
+      if (inTab) tabCount++;
 
       if (!inTab) continue;
       if (showFavoritesOnly && !a.is_favorite) continue;
@@ -74,11 +79,12 @@ export default function Assets() {
         if (!matchSymbol && !matchName) continue;
       }
       filtered.push(a);
+      if (a.is_favorite) favCount++;
     }
 
     const sorted = [...filtered].sort((a, b) => {
-      const va = getSortValue(a, sortConfig.key, periodKeys, positionMap);
-      const vb = getSortValue(b, sortConfig.key, periodKeys, positionMap);
+      const va = getSortValue(a, sortConfig.key, periodKeys);
+      const vb = getSortValue(b, sortConfig.key, periodKeys);
       if (typeof va === 'string') {
         return sortConfig.direction === 'asc' ? va.localeCompare(vb) : vb.localeCompare(va);
       }
@@ -86,7 +92,7 @@ export default function Assets() {
     });
 
     return { filteredAssets: sorted, totalCount: tabCount, favoritesCount: favCount };
-  }, [assets, activeTab, searchQuery, selectedPeriod, showFavoritesOnly, sortConfig, positionMap]);
+  }, [assets, activeTab, searchQuery, selectedPeriod, showFavoritesOnly, sortConfig]);
 
   if (loading) {
     return (
@@ -169,7 +175,7 @@ export default function Assets() {
         sortConfig={sortConfig}
         onSort={handleSort}
         onRowClick={handleRowClick}
-        onToggleFavorite={toggleFavorite}
+        onToggleFavorite={handleToggleFavorite}
         loading={false}
         totalCount={totalCount}
         favoritesCount={favoritesCount}

--- a/frontend/src/pages/Assets.jsx
+++ b/frontend/src/pages/Assets.jsx
@@ -10,7 +10,7 @@ function getSortValue(asset, sortKey, periodKeys, positionMap) {
     case 'symbol': return asset.symbol?.toLowerCase() || '';
     case 'price': return asset.last_fetched_price ?? -Infinity;
     case 'changePct': return asset[periodKeys.pct] ?? -Infinity;
-    case 'marketCap': return positionMap.get(asset.id)?.market_cap ?? -Infinity;
+    case 'marketCap': return asset.market_cap ?? -Infinity;
     case 'volume': return -Infinity;
     default: return 0;
   }
@@ -47,6 +47,7 @@ export default function Assets() {
       current_price: asset.last_fetched_price,
       day_change_pct: asset.change_1d_pct,
       currency: asset.currency,
+      is_favorite: asset.is_favorite,
     });
   };
 
@@ -60,8 +61,10 @@ export default function Assets() {
     let favCount = 0;
     for (const a of assets) {
       const inTab = activeTab === 'All' || a.asset_class === activeTab;
-      if (inTab) tabCount++;
-      if (a.is_favorite) favCount++;
+      if (inTab) {
+        tabCount++;
+        if (a.is_favorite) favCount++;
+      }
 
       if (!inTab) continue;
       if (showFavoritesOnly && !a.is_favorite) continue;


### PR DESCRIPTION
## Summary

- Decomposes the monolithic `Assets.jsx` (877 lines) into focused components matching the [finalized mock](mocks/assets-playground.html)
- Introduces `useAssetsData` hook for parallel API fetching (market data + positions) with optimistic favorite toggle
- New components: `AssetClassTabs`, `AssetsFilterRow`, `AssetsTable`, `AssetRow`, `SparklineCell`
- Integrates shared `AssetDetailSidebar` from dashboard with proper favorite sync (no double API calls)
- All filtering (asset class, search, favorites) and sorting happen client-side for instant feedback
- Procedural sparklines generated from change data with seeded PRNG for deterministic rendering

## Architecture

```
Assets.jsx (184 lines)
  +-- AssetClassTabs        (segmented control: All/Crypto/Stocks/ETFs/Forex)
  +-- AssetsFilterRow        (search + time period 1D/1W/1M + favorites toggle)
  +-- AssetsTable            (sortable table with header/body/footer)
  |     +-- AssetRow         (star, icon, symbol+name+badge, price, change, sparkline)
  |     +-- SparklineCell    (80x28 inline SVG)
  +-- AssetDetailSidebar     (shared component, opens on row click)
```

## Test plan

- [ ] Asset class tabs filter correctly with count badges
- [ ] Time period toggle (1D/1W/1M) switches change column values and sparkline shapes
- [ ] Search filters by symbol and name (client-side)
- [ ] Favorites toggle shows only starred assets with amber highlight
- [ ] Sortable columns (symbol, price, change, mkt cap) with directional indicators
- [ ] Row click opens asset detail sidebar
- [ ] Star toggle in table and sidebar stay in sync without double API calls
- [ ] Loading skeleton displays while data fetches
- [ ] Error state with retry button on API failure
- [ ] Portfolio badge shows on assets the user holds
- [ ] All numbers use tabular-nums, gains green, losses red

Closes #126

Generated with [Claude Code](https://claude.com/claude-code)