### PR TITLE
fix: assets page visual tweaks

### DIFF
--- a/frontend/src/components/assets/AssetRow.jsx
+++ b/frontend/src/components/assets/AssetRow.jsx
@@ -75,7 +75,7 @@ export function AssetRow({ asset, position, period, currency, onToggleFavorite, 
                 </span>
               )}
             </div>
-            <p className="text-[12px] text-[var(--text-faint)] mt-px truncate max-w-[220px]">
+            <p className="text-[12px] text-[var(--text-faint)] mt-px truncate">
               {asset.name}
             </p>
           </div>

--- a/frontend/src/components/dashboard/AssetDetailSidebar.jsx
+++ b/frontend/src/components/dashboard/AssetDetailSidebar.jsx
@@ -168,7 +168,7 @@ export function AssetDetailSidebar({ asset, isOpen, onClose, onFavoriteToggle })
       />
 
       {/* Panel */}
-      <div className="fixed top-0 right-0 z-50 h-dvh w-[420px] max-w-[90vw] bg-[var(--bg-secondary)] border-l border-[var(--border-primary)] shadow-2xl flex flex-col animate-slide-in-right">
+      <div className="fixed top-0 right-0 z-50 h-dvh w-[520px] max-w-[90vw] bg-[var(--bg-secondary)] border-l border-[var(--border-primary)] shadow-2xl flex flex-col animate-slide-in-right">
         {/* Header (sticky) */}
         <div className="px-6 pt-5 pb-4 border-b border-[var(--border-primary)] flex-shrink-0">
           <div className="flex items-center justify-between mb-2">


### PR DESCRIPTION
## Summary

Small visual fixes found during manual testing of #141.

- Remove `max-w-[220px]` hard cap on asset name — truncation is now driven by the column width via `min-w-0` + `truncate`, giving long names significantly more room
- Widen `AssetDetailSidebar` from 420px to 520px

🤖 Generated with [Claude Code](https://claude.ai/code)